### PR TITLE
eat: 사이드바 하단에 로그인/프로필 영역 추가

### DIFF
--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -15,7 +15,17 @@ export function LoginForm() {
     try {
       await new Promise((resolve) => setTimeout(resolve, 1500))
 
-      localStorage.setItem("auth_token", "mock_token_" + Date.now())
+      // Set auth token
+      localStorage.setItem("authToken", "mock_token_" + Date.now())
+
+      // Set mock user data
+      const mockUser = {
+        id: "1",
+        name: "사용자 이름",
+        email: "user@example.com",
+        avatar: undefined,
+      }
+      localStorage.setItem("user", JSON.stringify(mockUser))
 
       router.push("/")
     } catch (error) {

--- a/components/layout/dashboard-shell.tsx
+++ b/components/layout/dashboard-shell.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { type ReactNode, useState } from "react"
-import { Header } from "@/components/layout/header"
 import { Sidebar } from "@/components/layout/sidebar"
 
 interface DashboardShellProps {
@@ -14,10 +13,7 @@ export function DashboardShell({ children }: DashboardShellProps) {
   return (
     <div className="flex h-screen overflow-hidden bg-background">
       <Sidebar collapsed={sidebarCollapsed} onToggleCollapse={() => setSidebarCollapsed(!sidebarCollapsed)} />
-      <div className="flex flex-1 flex-col overflow-hidden">
-        <Header />
-        <main className="flex-1 overflow-auto">{children}</main>
-      </div>
+      <main className="flex-1 overflow-auto">{children}</main>
     </div>
   )
 }

--- a/components/layout/sidebar-profile.tsx
+++ b/components/layout/sidebar-profile.tsx
@@ -1,0 +1,199 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import Link from "next/link"
+import { User, Settings, LogOut, LogIn, ChevronUp } from "lucide-react"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Button } from "@/components/ui/button"
+import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip"
+import { cn } from "@/lib/utils"
+
+interface SidebarProfileProps {
+  collapsed: boolean
+}
+
+export function SidebarProfile({ collapsed }: SidebarProfileProps) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [isAuthenticated, setIsAuthenticated] = useState(false)
+
+  // Check auth status on mount and when storage changes
+  useEffect(() => {
+    const checkAuth = () => {
+      const authToken = localStorage.getItem("authToken")
+      setIsAuthenticated(!!authToken)
+    }
+
+    checkAuth()
+
+    // Listen for storage changes (for logout in other tabs)
+    window.addEventListener("storage", checkAuth)
+    return () => window.removeEventListener("storage", checkAuth)
+  }, [])
+
+  const handleLogout = () => {
+    localStorage.removeItem("authToken")
+    localStorage.removeItem("user")
+    setIsAuthenticated(false)
+    setIsOpen(false)
+  }
+
+  // Collapsed state
+  if (collapsed) {
+    if (!isAuthenticated) {
+      return (
+        <div className="p-4 border-t border-sidebar-border">
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Link href="/login">
+                  <Button variant="ghost" size="icon" className="h-10 w-10">
+                    <LogIn className="h-4 w-4" />
+                  </Button>
+                </Link>
+              </TooltipTrigger>
+              <TooltipContent side="right">
+                <p>로그인</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </div>
+      )
+    }
+
+    return (
+      <div className="p-4 border-t border-sidebar-border">
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-10 w-10 rounded-full"
+                onClick={() => setIsOpen(!isOpen)}
+              >
+                <Avatar className="h-8 w-8">
+                  <AvatarImage src="/placeholder.svg?height=32&width=32" alt="사용자" />
+                  <AvatarFallback>
+                    <User className="h-4 w-4" />
+                  </AvatarFallback>
+                </Avatar>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="right">
+              <p>프로필</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+
+        {/* Dropdown menu for collapsed state */}
+        {isOpen && (
+          <>
+            <div
+              className="fixed inset-0 z-40"
+              onClick={() => setIsOpen(false)}
+            />
+            <div className="absolute bottom-16 left-16 z-50 w-56 rounded-md border bg-popover p-1 shadow-md animate-in fade-in-0 zoom-in-95">
+              <Link href="/profile" onClick={() => setIsOpen(false)}>
+                <button className="relative flex w-full cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground">
+                  <User className="mr-2 h-4 w-4" />
+                  <span>프로필 보기</span>
+                </button>
+              </Link>
+              <Link href="/settings" onClick={() => setIsOpen(false)}>
+                <button className="relative flex w-full cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground">
+                  <Settings className="mr-2 h-4 w-4" />
+                  <span>설정</span>
+                </button>
+              </Link>
+              <div className="h-px my-1 bg-border" />
+              <button
+                onClick={() => {
+                  setIsOpen(false)
+                  handleLogout()
+                }}
+                className="relative flex w-full cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground"
+              >
+                <LogOut className="mr-2 h-4 w-4" />
+                <span>로그아웃</span>
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    )
+  }
+
+  // Expanded state - not authenticated
+  if (!isAuthenticated) {
+    return (
+      <div className="p-4 border-t border-sidebar-border">
+        <Link href="/login">
+          <Button variant="default" className="w-full justify-start h-10">
+            <LogIn className="mr-3 h-4 w-4" />
+            로그인
+          </Button>
+        </Link>
+      </div>
+    )
+  }
+
+  // Expanded state - authenticated
+  return (
+    <div className="p-4 border-t border-sidebar-border">
+      <div className="space-y-1">
+        {/* Profile button */}
+        <Button
+          variant="ghost"
+          className="w-full justify-start h-auto py-2 px-2 hover:bg-accent"
+          onClick={() => setIsOpen(!isOpen)}
+        >
+          <div className="flex items-center gap-3 w-full">
+            <Avatar className="h-8 w-8">
+              <AvatarImage src="/placeholder.svg?height=32&width=32" alt="사용자" />
+              <AvatarFallback>
+                <User className="h-4 w-4" />
+              </AvatarFallback>
+            </Avatar>
+            <div className="flex-1 text-left">
+              <p className="text-sm font-medium leading-none">사용자 이름</p>
+              <p className="text-xs text-muted-foreground mt-1">user@example.com</p>
+            </div>
+            <ChevronUp
+              className={cn(
+                "h-4 w-4 transition-transform duration-200",
+                isOpen && "rotate-180"
+              )}
+            />
+          </div>
+        </Button>
+
+        {/* Dropdown menu */}
+        {isOpen && (
+          <div className="pl-2 space-y-1 animate-in fade-in-0 slide-in-from-bottom-2">
+            <Link href="/profile" onClick={() => setIsOpen(false)}>
+              <Button variant="ghost" className="w-full justify-start h-9">
+                <User className="mr-3 h-4 w-4" />
+                프로필 보기
+              </Button>
+            </Link>
+            <Link href="/settings" onClick={() => setIsOpen(false)}>
+              <Button variant="ghost" className="w-full justify-start h-9">
+                <Settings className="mr-3 h-4 w-4" />
+                설정
+              </Button>
+            </Link>
+            <div className="h-px my-1 bg-border" />
+            <Button
+              variant="ghost"
+              className="w-full justify-start h-9 text-destructive hover:text-destructive"
+              onClick={handleLogout}
+            >
+              <LogOut className="mr-3 h-4 w-4" />
+              로그아웃
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -7,7 +7,7 @@ import { SidebarToggle } from "./sidebar-toggle"
 import { SidebarProjectInfo } from "./sidebar-project-info"
 import { SidebarProjectList } from "./sidebar-project-list"
 import { SidebarNav } from "./sidebar-nav"
-import { SidebarSettings } from "./sidebar-settings"
+import { SidebarProfile } from "./sidebar-profile"
 import { getProjects } from "@/lib/storage"
 import { mockProjects, type Project } from "@/lib/mock-data"
 
@@ -58,7 +58,7 @@ export function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
           <SidebarProjectInfo collapsed={collapsed} project={currentProject} />
           <SidebarProjectList collapsed={collapsed} projects={projects} currentProjectId={currentProjectId} />
           <SidebarNav collapsed={collapsed} />
-          <SidebarSettings collapsed={collapsed} />
+          <SidebarProfile collapsed={collapsed} />
         </div>
       </aside>
     </TooltipProvider>

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -1,25 +1,25 @@
-"use client"
-import { ChevronRight, Plus, FolderOpen, Settings, Menu, ChevronDown } from "lucide-react"
-import { Button } from "@/components/ui/button"
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
-import { cn } from "@/lib/utils"
-import { useState, useEffect } from "react"
-import { getProjects } from "@/lib/storage"
-import { mockProjects, type Project } from "@/lib/mock-data"
-import Link from "next/link"
+"use client";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { mockProjects, type Project } from "@/lib/mock-data";
+import { getProjects } from "@/lib/storage";
+import { cn } from "@/lib/utils";
+import { ChevronDown, ChevronRight, FolderOpen, Menu, Plus, Settings } from "lucide-react";
+import Link from "next/link";
+import { useEffect, useState } from "react";
 
 interface SidebarProps {
-  collapsed: boolean
-  onToggle: () => void
-  currentProjectId?: string | null
+  collapsed: boolean;
+  onToggle: () => void;
+  currentProjectId?: string | null;
 }
 
 export function Sidebar({ collapsed, onToggle, currentProjectId }: SidebarProps) {
-  const [projects, setProjects] = useState<Project[]>([])
-  const [showProjectList, setShowProjectList] = useState(false)
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [showProjectList, setShowProjectList] = useState(false);
 
   useEffect(() => {
-    const storedProjects = getProjects()
+    const storedProjects = getProjects();
     const combinedProjects = [
       ...mockProjects,
       ...storedProjects.map((p) => ({
@@ -34,9 +34,9 @@ export function Sidebar({ collapsed, onToggle, currentProjectId }: SidebarProps)
         createdAt: p.createdAt,
         updatedAt: p.updatedAt,
       })),
-    ]
-    setProjects(combinedProjects)
-  }, [])
+    ];
+    setProjects(combinedProjects);
+  }, []);
 
   const mainMenuItems = [
     {
@@ -49,15 +49,15 @@ export function Sidebar({ collapsed, onToggle, currentProjectId }: SidebarProps)
       label: "프로젝트 목록",
       href: "/projects",
     },
-  ]
+  ];
 
   const settingsItem = {
     icon: Settings,
     label: "설정",
     href: "/settings",
-  }
+  };
 
-  const currentProject = projects.find((p) => p.id === currentProjectId)
+  const currentProject = projects.find((p) => p.id === currentProjectId);
 
   return (
     <TooltipProvider>
@@ -127,7 +127,7 @@ export function Sidebar({ collapsed, onToggle, currentProjectId }: SidebarProps)
           {/* 메인 메뉴 항목들 */}
           <nav className="flex-1 p-4 space-y-2">
             {mainMenuItems.map((item, index) => {
-              const Icon = item.icon
+              const Icon = item.icon;
 
               if (collapsed) {
                 return (
@@ -143,7 +143,7 @@ export function Sidebar({ collapsed, onToggle, currentProjectId }: SidebarProps)
                       <p>{item.label}</p>
                     </TooltipContent>
                   </Tooltip>
-                )
+                );
               }
 
               return (
@@ -153,7 +153,7 @@ export function Sidebar({ collapsed, onToggle, currentProjectId }: SidebarProps)
                     {item.label}
                   </Button>
                 </Link>
-              )
+              );
             })}
           </nav>
 
@@ -183,5 +183,5 @@ export function Sidebar({ collapsed, onToggle, currentProjectId }: SidebarProps)
         </div>
       </aside>
     </TooltipProvider>
-  )
+  );
 }


### PR DESCRIPTION
- 헤더 컴포넌트 제거 및 레이아웃 단순화
- 사이드바 하단에 프로필 컴포넌트 추가