### PR TITLE
refactor: 설정 페이지 탭 구조 제거 및 세로 레이아웃으로 변경

### DIFF
--- a/components/pages/settings-page.tsx
+++ b/components/pages/settings-page.tsx
@@ -7,7 +7,6 @@ import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Bell, Download, Palette, Save, Shield, Trash2 } from "lucide-react";
 import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
@@ -75,254 +74,241 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
         </div>
       </div>
 
-      <div className="p-6">
-        <Tabs defaultValue="notifications" className="space-y-6">
-          <TabsList className="grid w-full grid-cols-3">
-            <TabsTrigger value="notifications">알림</TabsTrigger>
-            <TabsTrigger value="appearance">외관</TabsTrigger>
-            <TabsTrigger value="security">보안</TabsTrigger>
-          </TabsList>
-
-          {/* 알림 설정 */}
-          <TabsContent value="notifications" className="space-y-6">
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <Bell className="h-5 w-5" />
-                  알림 설정
-                </CardTitle>
-                <CardDescription>받고 싶은 알림을 선택하세요</CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-6">
-                <div className="space-y-4">
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <Label>이메일 알림</Label>
-                      <p className="text-sm text-muted-foreground">중요한 업데이트를 이메일로 받습니다</p>
-                    </div>
-                    <Switch
-                      checked={settings.emailNotifications}
-                      onCheckedChange={(checked) => handleSettingChange("emailNotifications", checked)}
-                    />
-                  </div>
-
-                  <Separator />
-
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <Label>푸시 알림</Label>
-                      <p className="text-sm text-muted-foreground">브라우저 푸시 알림을 받습니다</p>
-                    </div>
-                    <Switch
-                      checked={settings.pushNotifications}
-                      onCheckedChange={(checked) => handleSettingChange("pushNotifications", checked)}
-                    />
-                  </div>
-
-                  <Separator />
-
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <Label>프로젝트 업데이트</Label>
-                      <p className="text-sm text-muted-foreground">프로젝트 진행 상황 알림</p>
-                    </div>
-                    <Switch
-                      checked={settings.projectUpdates}
-                      onCheckedChange={(checked) => handleSettingChange("projectUpdates", checked)}
-                    />
-                  </div>
-
-                  <Separator />
-
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <Label>마감일 알림</Label>
-                      <p className="text-sm text-muted-foreground">마감일 임박 시 알림</p>
-                    </div>
-                    <Switch
-                      checked={settings.deadlineReminders}
-                      onCheckedChange={(checked) => handleSettingChange("deadlineReminders", checked)}
-                    />
-                  </div>
-
-                  <Separator />
-
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <Label>주간 리포트</Label>
-                      <p className="text-sm text-muted-foreground">매주 프로젝트 요약 리포트</p>
-                    </div>
-                    <Switch
-                      checked={settings.weeklyReports}
-                      onCheckedChange={(checked) => handleSettingChange("weeklyReports", checked)}
-                    />
-                  </div>
+      <div className="p-6 space-y-6">
+        {/* 알림 설정 */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Bell className="h-5 w-5" />
+              알림 설정
+            </CardTitle>
+            <CardDescription>받고 싶은 알림을 선택하세요</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <Label>이메일 알림</Label>
+                  <p className="text-sm text-muted-foreground">중요한 업데이트를 이메일로 받습니다</p>
                 </div>
-              </CardContent>
-            </Card>
-          </TabsContent>
+                <Switch
+                  checked={settings.emailNotifications}
+                  onCheckedChange={(checked) => handleSettingChange("emailNotifications", checked)}
+                />
+              </div>
 
-          {/* 외관 설정 */}
-          <TabsContent value="appearance" className="space-y-6">
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <Palette className="h-5 w-5" />
-                  외관 설정
-                </CardTitle>
-                <CardDescription>애플리케이션의 외관을 사용자 정의하세요</CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-6">
-                <div className="grid grid-cols-2 gap-4">
-                  <div className="space-y-2">
-                    <Label>테마</Label>
-                    <Select value={theme} onValueChange={handleThemeChange}>
-                      <SelectTrigger>
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="light">라이트</SelectItem>
-                        <SelectItem value="dark">다크</SelectItem>
-                        <SelectItem value="system">시스템 설정</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
+              <Separator />
 
-                  <div className="space-y-2">
-                    <Label>언어</Label>
-                    <Select value={settings.language} onValueChange={(value) => handleSettingChange("language", value)}>
-                      <SelectTrigger>
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="ko">한국어</SelectItem>
-                        <SelectItem value="en">English</SelectItem>
-                        <SelectItem value="ja">日本語</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label>시간대</Label>
-                    <Select value={settings.timezone} onValueChange={(value) => handleSettingChange("timezone", value)}>
-                      <SelectTrigger>
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="Asia/Seoul">서울 (UTC+9)</SelectItem>
-                        <SelectItem value="UTC">UTC (UTC+0)</SelectItem>
-                        <SelectItem value="America/New_York">뉴욕 (UTC-5)</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label>날짜 형식</Label>
-                    <Select
-                      value={settings.dateFormat}
-                      onValueChange={(value) => handleSettingChange("dateFormat", value)}
-                    >
-                      <SelectTrigger>
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="YYYY-MM-DD">2024-01-15</SelectItem>
-                        <SelectItem value="MM/DD/YYYY">01/15/2024</SelectItem>
-                        <SelectItem value="DD/MM/YYYY">15/01/2024</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
+              <div className="flex items-center justify-between">
+                <div>
+                  <Label>푸시 알림</Label>
+                  <p className="text-sm text-muted-foreground">브라우저 푸시 알림을 받습니다</p>
                 </div>
-              </CardContent>
-            </Card>
-          </TabsContent>
+                <Switch
+                  checked={settings.pushNotifications}
+                  onCheckedChange={(checked) => handleSettingChange("pushNotifications", checked)}
+                />
+              </div>
 
-          {/* 보안 설정 */}
-          <TabsContent value="security" className="space-y-6">
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <Shield className="h-5 w-5" />
-                  보안 설정
-                </CardTitle>
-                <CardDescription>계정 보안을 강화하세요</CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-6">
-                <div className="space-y-4">
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <Label>2단계 인증</Label>
-                      <p className="text-sm text-muted-foreground">추가 보안을 위한 2단계 인증 활성화</p>
-                    </div>
-                    <Switch
-                      checked={settings.twoFactorAuth}
-                      onCheckedChange={(checked) => handleSettingChange("twoFactorAuth", checked)}
-                    />
-                  </div>
+              <Separator />
 
-                  <Separator />
-
-                  <div className="space-y-2">
-                    <Label>세션 타임아웃</Label>
-                    <Select
-                      value={settings.sessionTimeout}
-                      onValueChange={(value) => handleSettingChange("sessionTimeout", value)}
-                    >
-                      <SelectTrigger className="w-48">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="15">15분</SelectItem>
-                        <SelectItem value="30">30분</SelectItem>
-                        <SelectItem value="60">1시간</SelectItem>
-                        <SelectItem value="240">4시간</SelectItem>
-                      </SelectContent>
-                    </Select>
-                    <p className="text-sm text-muted-foreground">비활성 상태에서 자동 로그아웃되는 시간</p>
-                  </div>
-
-                  <Separator />
-
-                  <div className="space-y-2">
-                    <Label>비밀번호 변경</Label>
-                    <Button variant="outline">비밀번호 변경</Button>
-                    <p className="text-sm text-muted-foreground">정기적인 비밀번호 변경을 권장합니다</p>
-                  </div>
+              <div className="flex items-center justify-between">
+                <div>
+                  <Label>프로젝트 업데이트</Label>
+                  <p className="text-sm text-muted-foreground">프로젝트 진행 상황 알림</p>
                 </div>
-              </CardContent>
-            </Card>
+                <Switch
+                  checked={settings.projectUpdates}
+                  onCheckedChange={(checked) => handleSettingChange("projectUpdates", checked)}
+                />
+              </div>
 
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-red-600">위험 구역</CardTitle>
-                <CardDescription>신중하게 사용하세요. 이 작업들은 되돌릴 수 없습니다.</CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <div className="flex items-center justify-between p-4 border border-red-200 rounded-lg">
-                  <div>
-                    <Label className="text-red-600">데이터 내보내기</Label>
-                    <p className="text-sm text-muted-foreground">모든 프로젝트 데이터를 내보냅니다</p>
-                  </div>
-                  <Button variant="outline" className="text-red-600 border-red-200 bg-transparent">
-                    <Download className="h-4 w-4 mr-2" />
-                    내보내기
-                  </Button>
-                </div>
+              <Separator />
 
-                <div className="flex items-center justify-between p-4 border border-red-200 rounded-lg">
-                  <div>
-                    <Label className="text-red-600">계정 삭제</Label>
-                    <p className="text-sm text-muted-foreground">계정과 모든 데이터를 영구적으로 삭제합니다</p>
-                  </div>
-                  <Button variant="destructive">
-                    <Trash2 className="h-4 w-4 mr-2" />
-                    계정 삭제
-                  </Button>
+              <div className="flex items-center justify-between">
+                <div>
+                  <Label>마감일 알림</Label>
+                  <p className="text-sm text-muted-foreground">마감일 임박 시 알림</p>
                 </div>
-              </CardContent>
-            </Card>
-          </TabsContent>
-        </Tabs>
+                <Switch
+                  checked={settings.deadlineReminders}
+                  onCheckedChange={(checked) => handleSettingChange("deadlineReminders", checked)}
+                />
+              </div>
+
+              <Separator />
+
+              <div className="flex items-center justify-between">
+                <div>
+                  <Label>주간 리포트</Label>
+                  <p className="text-sm text-muted-foreground">매주 프로젝트 요약 리포트</p>
+                </div>
+                <Switch
+                  checked={settings.weeklyReports}
+                  onCheckedChange={(checked) => handleSettingChange("weeklyReports", checked)}
+                />
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* 외관 설정 */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Palette className="h-5 w-5" />
+              외관 설정
+            </CardTitle>
+            <CardDescription>애플리케이션의 외관을 사용자 정의하세요</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>테마</Label>
+                <Select value={theme} onValueChange={handleThemeChange}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="light">라이트</SelectItem>
+                    <SelectItem value="dark">다크</SelectItem>
+                    <SelectItem value="system">시스템 설정</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2">
+                <Label>언어</Label>
+                <Select value={settings.language} onValueChange={(value) => handleSettingChange("language", value)}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="ko">한국어</SelectItem>
+                    <SelectItem value="en">English</SelectItem>
+                    <SelectItem value="ja">日本語</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2">
+                <Label>시간대</Label>
+                <Select value={settings.timezone} onValueChange={(value) => handleSettingChange("timezone", value)}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="Asia/Seoul">서울 (UTC+9)</SelectItem>
+                    <SelectItem value="UTC">UTC (UTC+0)</SelectItem>
+                    <SelectItem value="America/New_York">뉴욕 (UTC-5)</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2">
+                <Label>날짜 형식</Label>
+                <Select
+                  value={settings.dateFormat}
+                  onValueChange={(value) => handleSettingChange("dateFormat", value)}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="YYYY-MM-DD">2024-01-15</SelectItem>
+                    <SelectItem value="MM/DD/YYYY">01/15/2024</SelectItem>
+                    <SelectItem value="DD/MM/YYYY">15/01/2024</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* 보안 설정 */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Shield className="h-5 w-5" />
+              보안 설정
+            </CardTitle>
+            <CardDescription>계정 보안을 강화하세요</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <Label>2단계 인증</Label>
+                  <p className="text-sm text-muted-foreground">추가 보안을 위한 2단계 인증 활성화</p>
+                </div>
+                <Switch
+                  checked={settings.twoFactorAuth}
+                  onCheckedChange={(checked) => handleSettingChange("twoFactorAuth", checked)}
+                />
+              </div>
+
+              <Separator />
+
+              <div className="space-y-2">
+                <Label>세션 타임아웃</Label>
+                <Select
+                  value={settings.sessionTimeout}
+                  onValueChange={(value) => handleSettingChange("sessionTimeout", value)}
+                >
+                  <SelectTrigger className="w-48">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="15">15분</SelectItem>
+                    <SelectItem value="30">30분</SelectItem>
+                    <SelectItem value="60">1시간</SelectItem>
+                    <SelectItem value="240">4시간</SelectItem>
+                  </SelectContent>
+                </Select>
+                <p className="text-sm text-muted-foreground">비활성 상태에서 자동 로그아웃되는 시간</p>
+              </div>
+
+              <Separator />
+
+              <div className="space-y-2">
+                <Label>비밀번호 변경</Label>
+                <Button variant="outline">비밀번호 변경</Button>
+                <p className="text-sm text-muted-foreground">정기적인 비밀번호 변경을 권장합니다</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* 위험 구역 */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-red-600">위험 구역</CardTitle>
+            <CardDescription>신중하게 사용하세요. 이 작업들은 되돌릴 수 없습니다.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex items-center justify-between p-4 border border-red-200 rounded-lg">
+              <div>
+                <Label className="text-red-600">데이터 내보내기</Label>
+                <p className="text-sm text-muted-foreground">모든 프로젝트 데이터를 내보냅니다</p>
+              </div>
+              <Button variant="outline" className="text-red-600 border-red-200 bg-transparent">
+                <Download className="h-4 w-4 mr-2" />
+                내보내기
+              </Button>
+            </div>
+
+            <div className="flex items-center justify-between p-4 border border-red-200 rounded-lg">
+              <div>
+                <Label className="text-red-600">계정 삭제</Label>
+                <p className="text-sm text-muted-foreground">계정과 모든 데이터를 영구적으로 삭제합니다</p>
+              </div>
+              <Button variant="destructive">
+                <Trash2 className="h-4 w-4 mr-2" />
+                계정 삭제
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
 
         {/* 저장 버튼 */}
         <div className="flex justify-end pt-6">


### PR DESCRIPTION
## 📋 변경 사항

### 개요
설정 페이지의 사용성을 개선하기 위해 탭 구조를 제거하고, 모든 설정 항목을 단일 페이지에서 스크롤로 확인할 수 있도록 변경했습니다.

### 주요 변경 사항

#### Before ❌
- 3개의 탭(알림, 외관, 보안)으로 설정이 분리
- 탭 클릭으로 이동 필요
- 전체 설정을 한눈에 파악하기 어려움

#### After ✅
- 모든 설정 항목이 세로로 나열
- 스크롤만으로 모든 설정 확인 가능
- 더 나은 UX 제공

## 🔧 기술적 변경

### 제거된 컴포넌트
- \`Tabs\`
- \`TabsList\`  
- \`TabsTrigger\`
- \`TabsContent\`

### UI 구조 변경
4개의 Card 컴포넌트를 세로로 배치:
1. **알림 설정** - 이메일, 푸시, 프로젝트 업데이트, 마감일, 주간 리포트
2. **외관 설정** - 테마, 언어, 시간대, 날짜 형식
3. **보안 설정** - 2단계 인증, 세션 타임아웃, 비밀번호 변경
4. **위험 구역** - 데이터 내보내기, 계정 삭제

각 Card 간 \`space-y-6\` 클래스로 적절한 간격 적용

## 📁 수정된 파일
- \`components/pages/settings-page.tsx\` (254줄 → 241줄, -13줄)

## ✅ 이점
- ✨ **사용성 향상**: 탭 클릭 없이 스크롤만으로 모든 설정 확인
- ♿ **접근성 개선**: 모든 설정이 한 페이지에 표시
- 🧹 **코드 단순화**: Tabs 관련 컴포넌트 제거로 복잡도 감소
- 📱 **반응형 유지**: 기존 반응형 디자인 유지

## 🔗 관련 이슈
Closes #13

## ✔️ 체크리스트
- [x] 코드 변경 완료
- [x] 컴파일 에러 없음
- [x] 기존 기능 유지
- [ ] 테스트 완료
- [ ] 스크린샷 추가

## 📸 스크린샷
_(스크린샷 추가 예정)_

## 💬 추가 노트
모든 설정 항목의 기능은 그대로 유지되며, UI 구조만 변경되었습니다.