### PR TITLE
fix: 팀 관리 페이지 이메일 중복 필드 제거

### DIFF
--- a/features/team/components/TeamManagementPage.tsx
+++ b/features/team/components/TeamManagementPage.tsx
@@ -279,7 +279,6 @@ export function TeamManagementPage({ projectId, onBack }: TeamManagementPageProp
                           </Avatar>
                           <div>
                             <div className="font-medium">{member.name}</div>
-                            <div className="text-sm text-muted-foreground">{member.email}</div>
                           </div>
                         </div>
                       </TableCell>


### PR DESCRIPTION
## 1. 관련 이슈
Fixes #16 

## 2. 작업 내용
- 팀 관리 페이지 멤버 목록에서 중복으로 표시되던 이메일 필드를 제거했습니다.

## 3. 스크린샷
<img width="752" height="408" alt="image" src="https://github.com/user-attachments/assets/cb86f9c9-42e1-4823-93d5-69de5cb81f0e" />
