### PR TITLE
refactor: ProjectLayoutClient을 ProjectClient로 이름 변경

### DIFF
--- a/app/(dashboard)/project/[id]/layout.tsx
+++ b/app/(dashboard)/project/[id]/layout.tsx
@@ -1,7 +1,7 @@
 import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
 import getQueryClient from '@/shared/lib/queries/getQueryClient';
 import { getProjectById, getProjectTasks } from '@/shared/lib/queries/projectService';
-import { ProjectLayoutClient } from '@/shared/components/project/components/ProjectLayoutClient';
+import { ProjectClient } from '@/shared/components/project/components/ProjectClient';
 
 /**
  * 프로젝트 상세 페이지 레이아웃
@@ -38,7 +38,7 @@ export default async function ProjectLayout({ children, params }: ProjectLayoutP
   // dehydrate: QueryClient 상태를 직렬화하여 클라이언트로 전달
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
-      <ProjectLayoutClient projectId={params.id}>{children}</ProjectLayoutClient>
+      <ProjectClient projectId={params.id}>{children}</ProjectClient>
     </HydrationBoundary>
   );
 }

--- a/shared/components/project/components/ProjectClient.tsx
+++ b/shared/components/project/components/ProjectClient.tsx
@@ -6,18 +6,23 @@ import { QUERY_KEYS } from '@/shared/hooks/queries/useProjectQuery';
 import { ProjectHeader } from './ProjectHeader';
 import { ViewNavigator } from './ViewNavigator';
 
-interface ProjectLayoutClientProps {
+interface ProjectClientProps {
   projectId: string;
   children: React.ReactNode;
 }
 
 /**
- * 프로젝트 레이아웃 클라이언트 컴포넌트
+ * 프로젝트 클라이언트 컴포넌트
  *
  * HydrationBoundary로 주입된 데이터를 사용하여
  * 공통 헤더와 뷰 네비게이션을 렌더링합니다.
+ *
+ * 역할:
+ * - 서버에서 prefetch된 프로젝트 데이터 소비
+ * - 공통 헤더 및 네비게이션 제공
+ * - 사용자 인터랙션 처리 (라우팅 등)
  */
-export function ProjectLayoutClient({ projectId, children }: ProjectLayoutClientProps) {
+export function ProjectClient({ projectId, children }: ProjectClientProps) {
   const router = useRouter();
 
   // HydrationBoundary로 주입된 데이터 사용 (즉시 사용 가능, queryFn 불필요)


### PR DESCRIPTION
## 변경 사항
`ProjectLayoutClient` → `ProjectClient`로 네이밍 변경

## 목적
- Next.js의 `layout.tsx`와 혼동되는 네이밍 개선
- 업계 표준 네이밍 패턴(`Client` 접미사) 준수
- 코드 가독성 향상

## 변경 내역
- ✅ 파일명 변경: `ProjectLayoutClient.tsx` → `ProjectClient.tsx`
- ✅ 컴포넌트명 변경: `ProjectLayoutClient` → `ProjectClient`
- ✅ 인터페이스명 변경: `ProjectLayoutClientProps` → `ProjectClientProps`
- ✅ import 경로 업데이트: `layout.tsx`

## 영향 범위
- 내부 리팩토링만 수행
- 기능 변경 없음
- 사용자에게 보이는 변화 없음

## 체크리스트
- [x] TypeScript 컴파일 확인
- [x] Lint/Prettier 통과 (자동 실행됨)
- [x] 로컬 테스트 완료

## 참고
- Vercel 템플릿 및 Next.js 14+ 표준 네이밍 패턴 준수
- "Shell & Core" 패턴에서 Server/Client 구분 명확화