### PR TITLE
feat(auth): 구글 소셜 로그인 기능 구현

### DIFF
--- a/features/auth/components/GoogleLoginButton.tsx
+++ b/features/auth/components/GoogleLoginButton.tsx
@@ -28,7 +28,7 @@ export function GoogleLoginButton({
     const idToken = credentialResponse.credential;
 
     if (!idToken) {
-      console.error('Google 로그인 실패: id_token을 받지 못했습니다.');
+      console.error('id_token을 받지 못했습니다.');
       setIsLoggingIn(false);
       onLoginError();
       return;
@@ -46,18 +46,36 @@ export function GoogleLoginButton({
         throw new Error(`API 서버 오류: ${response.status}`);
       }
 
-      const { token, user } = await response.json();
-      onLoginSuccess(user, token); // 성공! 부모에게 알림
-      console.log('로그인 성공, 사용자 정보:', user);
+      const authorizationHeader = response.headers.get('authorization');
+      let token = null;
+
+      if (authorizationHeader && authorizationHeader.startsWith('Bearer ')) {
+        // 'Bearer ' 라는 접두사를 제거한 순수 토큰 값만 저장합니다.
+        token = authorizationHeader.split(' ')[1];
+      }
+
+      const refreshToken = response.headers.get('refresh-token');
+      if (refreshToken) {
+        localStorage.setItem('refreshToken', refreshToken); // <b><-- 중요!</b>
+      }
+
+      const user = await response.json();
+
+      if (user && token) {
+        onLoginSuccess(user, token); // 성공!
+        console.log('Google 로그인 성공:', user);
+      } else {
+        // 둘 중 하나라도 없으면 에러 처리
+        throw new Error('서버 응답에서 user(body) 또는 token(header)을 받지 못했습니다.');
+      }
     } catch (error) {
       console.error('로그인 API 연동 실패:', error);
-      onLoginError(); // 실패! 부모에게 알림
+      onLoginError();
     } finally {
       setIsLoggingIn(false);
     }
   };
 
-  // 구글 로그인 자체 실패 시 (기존과 동일)
   const handleError = () => {
     console.error('Google 로그인 실패');
     setIsLoggingIn(false);

--- a/features/profile/components/ProfilePage.tsx
+++ b/features/profile/components/ProfilePage.tsx
@@ -15,10 +15,15 @@ interface ProfilePageProps {
   onBack: () => void;
 }
 
+interface UserProfile {
+  id: number;
+  name: string;
+  email: string;
+  isNewUser: boolean;
+}
+
 export function ProfilePage({ onBack }: ProfilePageProps) {
-  const [isLoading, setIsLoading] = useState(true);
-  const [isEditing, setIsEditing] = useState(false);
-  const [profileData, setProfileData] = useState({
+  const defaultProfileData = {
     name: '김철수',
     email: 'kim.chulsoo@company.com',
     phone: '010-1234-5678',
@@ -28,17 +33,34 @@ export function ProfilePage({ onBack }: ProfilePageProps) {
     department: '개발팀',
     position: '시니어 프로젝트 매니저',
     skills: ['프로젝트 관리', '팀 리더십', '일정 관리', '리스크 관리', 'Agile/Scrum'],
-  });
+  };
 
-  const [editData, setEditData] = useState(profileData);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isEditing, setIsEditing] = useState(false);
+  const [profileData, setProfileData] = useState(defaultProfileData);
+  const [editData, setEditData] = useState(defaultProfileData);
 
   useEffect(() => {
-    // Simulate loading profile data
-    const timer = setTimeout(() => {
-      setIsLoading(false);
-    }, 500);
+    const storedUser = localStorage.getItem('user');
 
-    return () => clearTimeout(timer);
+    if (storedUser) {
+      try {
+        const loggedInUser: UserProfile = JSON.parse(storedUser);
+
+        const mergedProfileData = {
+          ...defaultProfileData,
+          name: loggedInUser.name,
+          email: loggedInUser.email,
+        };
+
+        setProfileData(mergedProfileData);
+        setEditData(mergedProfileData);
+      } catch (error) {
+        console.error('localStorage user 파싱 오류:', error);
+      }
+    }
+
+    setIsLoading(false);
   }, []);
 
   const handleEdit = () => {

--- a/shared/layout/SidebarProfile.tsx
+++ b/shared/layout/SidebarProfile.tsx
@@ -27,8 +27,18 @@ export function SidebarProfile({ collapsed }: SidebarProfileProps) {
       const storedUser = localStorage.getItem('user');
 
       if (authToken && storedUser) {
-        setIsAuthenticated(true);
-        // setUser(JSON.parse(storedUser));
+        try {
+          const loggedInUser: UserProfile = JSON.parse(storedUser);
+
+          setUser(loggedInUser);
+          setIsAuthenticated(true);
+
+          // setIsAuthenticated(true);
+          // setUser(JSON.parse(storedUser));
+        } catch (error) {
+          console.log('localStorage user 파싱 오류:', error);
+          handleLogout(); // 강제 로그아웃
+        }
       } else {
         setIsAuthenticated(false);
         setUser(null);


### PR DESCRIPTION
**주요 구현 사항**

1. 구글 소셜 로그인 연동

- GoogleLoginButton에서 받은 idToken을 백엔드(/api/auth/google/login)로 전송합니다.

2. 백엔드 응답 처리 

- 백엔드 API 명세에 맞춰, Response Headers의 authorization (액세스 토큰)과 refresh-token을 읽도록 수정했습니다.

- Response Body의 user 객체를 파싱합니다.

3. 로그인 상태 영속성 (Persistence)

- SidebarProfile의 useEffect 로직을 수정하여, 새로고침 시 localStorage의 authToken과 user 정보를 읽어와 로그인 상태를 복원합니다.

- GoogleLoginButton에서 받은 refresh-token도 localStorage에 저장합니다.

4. 프로필 페이지 연동

- ProfilePage가 마운트될 때 localStorage의 user 정보(name, email)를 읽어와 목 데이터(김철수) 대신 표시하도록 수정했습니다.

- 데이터 로드 후 isLoading 상태를 false로 변경하는 로직을 추가했습니다.

추가사항) ProfilePage에 phone, bio, skills 같은 상세 정보는 아직 연동 전입니다. 이건 다음 스텝에서 "프로필 상세 조회 API"를 호출해서 받아와야 할 것 같습니다.
