### PR TITLE
feat: 간트 차트 에디터 설명 및 타입 필드 숨김 처리

### DIFF
--- a/features/gantt/components/GanttChartView.tsx
+++ b/features/gantt/components/GanttChartView.tsx
@@ -3,20 +3,21 @@
 import { useToast } from '@/shared/hooks/useToast';
 import { mockHierarchicalTasks } from '@/shared/lib/mockGanttData';
 import { getCurrentProject, saveProject, type StoredProject } from '@/shared/lib/storage';
-import { taskToGantt, ganttToTask } from '@/shared/lib/taskAdapters';
+import { ganttToTask, taskToGantt } from '@/shared/lib/taskAdapters';
 import { Button } from '@/shared/ui/button';
 import {
+  ContextMenu,
+  defaultEditorItems,
+  Editor,
   Gantt,
   Toolbar,
   Willow,
-  ContextMenu,
-  Editor,
-  type ITask as SvarTask,
   type IApi,
+  type ITask as SvarTask,
 } from '@svar-ui/react-gantt';
 import '@svar-ui/react-gantt/all.css';
-import { Save, RefreshCw } from 'lucide-react';
-import { useState, useRef } from 'react';
+import { RefreshCw, Save } from 'lucide-react';
+import { useRef, useState } from 'react';
 
 interface GanttChartViewProps {
   projectId: string;
@@ -158,11 +159,18 @@ export function GanttChartView({ projectId: _projectId }: GanttChartViewProps) {
       </div>
 
       {/* SVAR Gantt 차트 */}
-      <div className="border rounded-lg bg-card overflow-hidden" style={{ minHeight: '600px' }}>
+      <div className="border rounded-lg bg-card overflow-hidden">
         <Willow>
           <ContextMenu api={apiRef.current || undefined}>
             {apiInitialized && apiRef.current && <Toolbar api={apiRef.current} />}
-            {apiInitialized && apiRef.current && <Editor api={apiRef.current} />}
+            {apiInitialized && apiRef.current && (
+              <Editor
+                api={apiRef.current}
+                items={defaultEditorItems.filter(
+                  (item: { key: string }) => item.key !== 'details' && item.key !== 'type'
+                )}
+              />
+            )}
             <Gantt
               tasks={localTasks}
               links={[]}


### PR DESCRIPTION
## 📝 Summary
간트 차트 에디터에서 불필요한 '설명(details)' 및 '타입(type)' 필드를 숨김 처리하여 사용자 경험을 개선했습니다.

## 🎯 Background
@svar-ui/react-gantt의 기본 Editor는 모든 필드를 표시하지만, FlowPlan에서는 '설명'과 '타입' 필드를 사용하지 않아 사용자에게 혼란을 줄 수 있었습니다.

## 🔧 Changes
### Editor 필터링
- `defaultEditorItems`를 필터링하여 `details`와 `type` 필드 제거
- 필요한 필드만 표시 (작업명, 담당자, 날짜, 기간, 진행률, 우선순위 등)

### 코드 정리
- import 문 자동 정렬 (Prettier/ESLint)
- 불필요한 인라인 스타일 제거

## ✅ Test Plan
- [x] 간트 차트 에디터 열기
- [x] '설명' 및 '타입' 필드가 표시되지 않는지 확인
- [x] 나머지 필드들이 정상 작동하는지 확인
- [x] 작업 수정 후 저장이 정상 작동하는지 확인