### PR TITLE
fix: 프로젝트 생성 후 실제 WBS 페이지로 이동하도록 수정

### DIFF
--- a/app/(dashboard)/new-project/page.tsx
+++ b/app/(dashboard)/new-project/page.tsx
@@ -1,32 +1,20 @@
 'use client';
 
 import { NewProjectPage } from '@/features/project-creation/components/NewProjectPage';
-import { saveProject } from '@/shared/lib/storage';
-import router from 'next/router';
+import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
 export default function NewProject() {
+  const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
 
-  const handleProjectCreate = async (projectData: any) => {
-    setIsLoading(true);
-    // AI 프로젝트 생성 시뮬레이션
-    setTimeout(() => {
-      const newProject = {
-        id: `project-${Date.now()}`,
-        title: `${projectData.subject} 프로젝트`,
-        description: projectData.description || `${projectData.subject} 관련 프로젝트`,
-        teamSize: projectData.teamSize || 5,
-        duration: projectData.duration || 90,
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-        wbsTasks: [],
-      };
-
-      saveProject(newProject);
-      setIsLoading(false);
-      router.push(`/project/${newProject.id}`);
-    }, 3000);
+  const handleProjectCreate = (projectData: any) => {
+    if (projectData.id) {
+      router.push(`/project/${projectData.id}/wbs-table`);
+    } else {
+      alert('프로젝트가 생성되었으나 ID를 찾을 수 없습니다.');
+      router.push('/');
+    }
   };
 
   return <NewProjectPage onSubmit={handleProjectCreate} isLoading={isLoading} />;


### PR DESCRIPTION
## 요약
프로젝트 생성(`new-project`) 페이지에 남아있던 더미 데이터 생성 로직(`setTimeout`, `saveProject`)을 제거하고, API 응답으로 받은 실제 ID를 사용해 이동하도록 수정했습니다.

## 주요 변경 사항
1. **Mock 제거:** 가짜 ID 생성 및 로컬 스토리지 저장 로직을 삭제했습니다.
2. **리다이렉션 수정:** `ProjectForm`에서 전달받은 실제 `projectId`를 사용하여 `/project/{id}/wbs-table`로 이동합니다.
3. **Router 수정:** `next/router` 대신 App Router용 `next/navigation` 훅으로 교체했습니다.