### PR TITLE
feat(gantt): 간트차트 작업 수정 API 연동

### DIFF
--- a/features/gantt/components/GanttChartView.tsx
+++ b/features/gantt/components/GanttChartView.tsx
@@ -59,6 +59,18 @@ const dhtmlxDateToApi = (dateStr: string): string => {
   return `${year}-${month}-${day}`;
 };
 
+/**
+ * progress 값에 따른 status 결정
+ * - 0: TODO
+ * - 1~99: IN_PROGRESS
+ * - 100: DONE
+ */
+const getStatusFromProgress = (progress: number): 'TODO' | 'IN_PROGRESS' | 'DONE' => {
+  if (progress === 0) return 'TODO';
+  if (progress === 100) return 'DONE';
+  return 'IN_PROGRESS';
+};
+
 export function GanttChartView() {
   const params = useParams();
   const projectId = params.id as string;
@@ -219,12 +231,42 @@ export function GanttChartView() {
     gantt.attachEvent('onAfterTaskUpdate', (id: any, task: any) => {
       console.log('📝 [Gantt] onAfterTaskUpdate:', { id, task, progress: task.progress });
       const startDateStr = gantt.templates.format_date(task.start_date);
+
+      // endDate 계산: start_date + duration
+      const endDate = gantt.calculateEndDate(task.start_date, task.duration);
+      const endDateStr = gantt.templates.format_date(endDate);
+
+      const progressValue = Math.round(task.progress * 100);
       updateMutationRef.current.mutate({
         taskId: Number(id),
         updates: {
           name: task.text,
           startDate: dhtmlxDateToApi(startDateStr),
-          progress: Math.round(task.progress * 100),
+          endDate: dhtmlxDateToApi(endDateStr),
+          progress: progressValue,
+          status: getStatusFromProgress(progressValue),
+        },
+      });
+    });
+
+    // 진행률 드래그 완료 이벤트 (drag_progress 사용 시)
+    gantt.attachEvent('onAfterTaskDrag', (id: any, mode: any, e: any) => {
+      const task = gantt.getTask(id);
+      console.log('🎯 [Gantt] onAfterTaskDrag:', { id, mode, progress: task.progress });
+
+      const startDateStr = gantt.templates.format_date(task.start_date as Date);
+      const endDate = gantt.calculateEndDate(task.start_date as Date, task.duration || 1);
+      const endDateStr = gantt.templates.format_date(endDate as Date);
+
+      const progressValue = Math.round((task.progress || 0) * 100);
+      updateMutationRef.current.mutate({
+        taskId: Number(id),
+        updates: {
+          name: task.text,
+          startDate: dhtmlxDateToApi(startDateStr),
+          endDate: dhtmlxDateToApi(endDateStr),
+          progress: progressValue,
+          status: getStatusFromProgress(progressValue),
         },
       });
     });

--- a/shared/api/taskTypes.ts
+++ b/shared/api/taskTypes.ts
@@ -51,7 +51,7 @@ export interface CreateTaskDto {
  */
 export interface UpdateTaskDto {
   name?: string;
-  assigneeId?: number;
+  assigneeEmail?: string; // 담당자 이메일 (백엔드 스웨거 스펙)
   startDate?: string; // YYYY-MM-DD
   endDate?: string; // YYYY-MM-DD
   status?: string;


### PR DESCRIPTION
## 📋 개요
간트차트에서 작업 수정 시 백엔드 API와 정상적으로 연동되도록 수정했습니다.

## ✨ 변경 사항

### 1. endDate 필드 추가
- 백엔드 스펙에 맞춰 `startDate`와 함께 `endDate`도 전송
- `gantt.calculateEndDate(start_date, duration)`으로 자동 계산

### 2. 진행률 드래그 이벤트 핸들러 추가
- `onAfterTaskDrag` 이벤트 추가
- 진행률 막대 드래그 시 API 호출되도록 처리

### 3. progress ↔ status 자동 연동
- 백엔드에서 progress와 status가 연동되어야 함
- [getStatusFromProgress()](cci:1://file:///Users/tnemn/Documents/projects/FlowPlan/features/gantt/components/GanttChartView.tsx:61:0-71:2) 헬퍼 함수 추가:
  | Progress | Status |
  |----------|--------|
  | 0% | TODO |
  | 1~99% | IN_PROGRESS |
  | 100% | DONE |

### 4. 타입 정의 수정
- `UpdateTaskDto.assigneeId` → `assigneeEmail` 변경 (백엔드 스웨거 스펙 반영)

## 📁 변경된 파일
- [features/gantt/components/GanttChartView.tsx](cci:7://file:///Users/tnemn/Documents/projects/FlowPlan/features/gantt/components/GanttChartView.tsx:0:0-0:0)
- [shared/api/taskTypes.ts](cci:7://file:///Users/tnemn/Documents/projects/FlowPlan/shared/api/taskTypes.ts:0:0-0:0)

## ✅ 테스트
- [x] 작업 날짜 드래그 후 새로고침 시 유지 확인
- [x] 진행률 드래그 후 새로고침 시 유지 확인
- [x] API 요청에 endDate, status 포함 확인