### PR TITLE
Fix/ 프로젝트 상세 진입 시 WBS 데이터 미표시 이슈 해결Fix/missing queryfn tasks

### DIFF
--- a/app/(dashboard)/new-project/page.tsx
+++ b/app/(dashboard)/new-project/page.tsx
@@ -8,12 +8,44 @@ export default function NewProject() {
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
 
-  const handleProjectCreate = (projectData: any) => {
-    if (projectData.id) {
+  const handleProjectCreate = async (projectData: any) => {
+    // 1. 유효성 검사
+    if (!projectData.id) {
+      alert('프로젝트 ID가 없습니다.');
+      return;
+    }
+
+    try {
+      setIsLoading(true); // 로딩 시작 (Form은 이걸 받아서 UI를 잠글 수 있음)
+
+      // 2. [핵심] 실제 WBS 생성 API 호출 (질문하신 부분!)
+      // 이 로직이 page.tsx에 있는 것이 맞습니다.
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/projects/wbs`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${localStorage.getItem('authToken')}`,
+        },
+        body: JSON.stringify({
+          projectId: projectData.id, // 스웨거에 있던 projectId 추가
+          markdownContent: projectData.markdown, // 키 이름을 markdown -> markdownContent 로 변경
+        }),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text(); // 서버가 보낸 에러 메시지를 텍스트로 읽음
+        console.error(`서버 에러 발생! 상태코드: ${response.status}`);
+        console.error('서버 응답 메시지:', errorText);
+
+        throw new Error(`서버 에러(${response.status}): ${errorText}`);
+      }
+
       router.push(`/project/${projectData.id}/wbs-table`);
-    } else {
-      alert('프로젝트가 생성되었으나 ID를 찾을 수 없습니다.');
-      router.push('/');
+    } catch (error) {
+      console.error(error);
+      alert('오류가 발생했습니다.');
+    } finally {
+      setIsLoading(false); // 로딩 끝
     }
   };
 

--- a/features/wbs/components/WBSTableView.tsx
+++ b/features/wbs/components/WBSTableView.tsx
@@ -2,17 +2,56 @@
 
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useParams } from 'next/navigation';
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import { HierarchicalWBSTable } from './HierarchicalWbsTable';
 import { useTaskOperations } from '../hooks/useTaskOperations';
 import { TaskDetailPanel } from '@/shared/components/project/TaskDetailPanel';
-import type { Task } from '@/shared/lib/apiTypes';
+import type { Task, BackendTask } from '@/shared/lib/apiTypes';
+import { apiService } from '@/shared/lib/apiService';
 
 /**
  * WBS Table View 컴포넌트
  *
  * 계층적 WBS 테이블을 렌더링합니다.
  */
+
+// 컴포넌트 밖 (export function WBSTableView() 위쪽)
+
+function buildTaskTree(backendTasks: BackendTask[]): Task[] {
+  if (!backendTasks) return [];
+
+  const taskMap = new Map<string, Task>();
+  const rootTasks: Task[] = [];
+
+  // 1. 변환
+  backendTasks.forEach((bt) => {
+    const task: Task = {
+      task_id: String(bt.id),
+      parent_id: bt.parent === bt.id || !bt.parent ? null : String(bt.parent),
+      name: bt.name,
+      start_date: bt.start,
+      end_date: bt.end,
+      duration_days: bt.duration,
+      progress: bt.progress,
+      status: bt.status === 'TODO' ? '할일' : bt.status === 'IN_PROGRESS' ? '진행중' : '완료', // 백엔드 값에 맞춰 수정 필요
+      assignee: bt.assigneeEmail,
+      subtasks: [],
+    };
+    taskMap.set(task.task_id, task);
+  });
+
+  // 2. 구조화
+  taskMap.forEach((task) => {
+    if (task.parent_id && taskMap.has(task.parent_id)) {
+      taskMap.get(task.parent_id)?.subtasks?.push(task);
+    } else {
+      rootTasks.push(task);
+    }
+  });
+
+  return rootTasks;
+}
+
 export function WBSTableView() {
   const params = useParams();
   const projectId = params.id as string;
@@ -22,10 +61,15 @@ export function WBSTableView() {
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
   const [isTaskDetailOpen, setIsTaskDetailOpen] = useState(false);
 
-  // Tasks 조회 (localStorage mock - 백엔드 연동 전)
-  const { data: tasks = [] } = useQuery({
+  const { data: rawTasks = [], isLoading } = useQuery({
     queryKey: ['tasks', projectId],
+    queryFn: () => apiService.getProjectTasks(projectId), // 이 줄이 핵심입니다!
   });
+
+  const tasks = useMemo(() => {
+    // buildTaskTree 함수가 없다면 아래에 정의해줘야 합니다.
+    return buildTaskTree(rawTasks);
+  }, [rawTasks]);
 
   const { findTaskById, handleTaskUpdate, handleTaskDelete, handleTaskAdd } = useTaskOperations(
     projectId,

--- a/shared/lib/apiService.ts
+++ b/shared/lib/apiService.ts
@@ -12,6 +12,7 @@ import type {
   RealtimeEvent,
   TeamMember,
   UserRole,
+  BackendTask,
 } from './apiTypes';
 
 class ApiService {
@@ -21,31 +22,66 @@ class ApiService {
 
   constructor(baseUrl: string = process.env.NEXT_PUBLIC_API_URL || '/api') {
     this.baseUrl = baseUrl;
-    this.token = typeof window !== 'undefined' ? localStorage.getItem('auth_token') : null;
+    this.token = typeof window !== 'undefined' ? localStorage.getItem('authToken') : null;
   }
 
   private async request<T>(endpoint: string, options: RequestInit = {}): Promise<ApiResponse<T>> {
+    // 1. URL 정리
     const url = `${this.baseUrl}${endpoint}`;
-    const headers = {
-      'Content-Type': 'application/json',
-      ...(this.token && { Authorization: `Bearer ${this.token}` }),
-      ...options.headers,
+
+    // 2. 토큰 가져오기
+    const currentToken = typeof window !== 'undefined' ? localStorage.getItem('authToken') : null;
+
+    // 3. 헤더 구성 (일단 토큰만 넣음)
+    const headers: Record<string, string> = {
+      ...(currentToken && { Authorization: `Bearer ${currentToken}` }),
     };
+
+    // 4. options에서 들어온 헤더가 있으면 합치기 (단, Content-Type은 제외)
+    if (options.headers) {
+      Object.entries(options.headers).forEach(([key, value]) => {
+        if (key.toLowerCase() !== 'content-type') {
+          headers[key] = value as string;
+        }
+      });
+    }
+
+    // 5. 메소드 확인
+    const method = options.method ? options.method.toUpperCase() : 'GET';
+
+    // 6. [중요] GET이 아닐 때만 Content-Type 추가
+    if (method !== 'GET') {
+      headers['Content-Type'] = 'application/json';
+    }
+
+    console.log(`📡 [API 요청] ${method} ${url}`);
 
     try {
       const response = await fetch(url, {
         ...options,
-        headers,
+        method,
+        headers, // 깨끗하게 정리된 헤더 사용
+        // [핵심] GET 요청일 때 body가 있으면 에러나는 브라우저/서버가 있음. 강제로 undefined 처리.
+        body: method === 'GET' ? undefined : options.body,
       });
 
+      const text = await response.text();
+      console.log(`🔢 [상태 코드] ${response.status}`);
+
       if (!response.ok) {
-        const error: ApiError = await response.json();
-        throw new Error(error.message || 'API request failed');
+        // 에러 메시지 파싱
+        let errorMessage = text;
+        try {
+          const errorJson = JSON.parse(text);
+          errorMessage = errorJson.message || JSON.stringify(errorJson);
+        } catch {}
+        throw new Error(`API Error (${response.status}): ${errorMessage}`);
       }
 
-      return await response.json();
+      if (!text) return {} as any;
+      return JSON.parse(text);
     } catch (error) {
-      console.error('API request failed:', error);
+      console.error('Final API Error:', error);
       throw error;
     }
   }
@@ -62,7 +98,7 @@ class ApiService {
 
     if (response.success && response.data.token) {
       this.token = response.data.token;
-      localStorage.setItem('auth_token', this.token);
+      localStorage.setItem('authToken', this.token);
     }
 
     return response;
@@ -70,7 +106,7 @@ class ApiService {
 
   async logout(): Promise<void> {
     this.token = null;
-    localStorage.removeItem('auth_token');
+    localStorage.removeItem('authToken');
   }
 
   // 프로젝트 관련
@@ -141,6 +177,24 @@ class ApiService {
     return this.request<void>(`/projects/${projectId}/tasks/${taskId}`, {
       method: 'DELETE',
     });
+  }
+
+  async getProjectTasks(projectId: string): Promise<BackendTask[]> {
+    // 1. 스웨거에 적힌 URL 경로
+    const endpoint = `/api/tasks/projects/${projectId}/tasks`;
+
+    // 2. this.request를 사용해서 호출 (토큰 자동 포함됨)
+    // 백엔드 응답 구조가 { projectId: ..., tasks: [...] } 이므로 타입을 이렇게 정의
+    const response = await this.request<{ tasks: BackendTask[] }>(endpoint, {
+      method: 'GET',
+    });
+
+    // 3. 응답 데이터(response.data) 안에 있는 tasks 배열만 꺼내서 반환
+    if (response.success && response.data && response.data.tasks) {
+      return response.data.tasks;
+    }
+
+    return [];
   }
 
   // 댓글 관련

--- a/shared/lib/apiTypes.ts
+++ b/shared/lib/apiTypes.ts
@@ -117,7 +117,7 @@ export interface Task {
   duration_days: number;
   progress: number; // 0-100
   status: TaskStatus;
-  subtasks: Task[];
+  subtasks?: Task[];
 }
 
 // 백엔드 API WBS 응답 타입
@@ -190,4 +190,16 @@ export interface RealtimeEvent {
   userId: string;
   projectId: string;
   timestamp: string;
+}
+
+export interface BackendTask {
+  id: number;
+  parent: number; // 최상위면 자기 자신 ID거나 null 일 수 있음 (명세 확인 필요, 여기선 parent ID)
+  name: string;
+  start: string;
+  end: string;
+  duration: number;
+  progress: number;
+  status: 'TODO' | 'IN_PROGRESS' | 'DONE'; // 백엔드 Enum 예시
+  assigneeEmail: string;
 }


### PR DESCRIPTION
## 📌 작업 배경 (Background)
- 프로젝트 목록에서 상세 페이지로 진입할 때, `localStorage`의 현재 프로젝트 ID 설정 시점과 데이터 조회 시점이 어긋나 WBS 테이블이 비어 보이는 문제가 있었습니다. (새로고침 시에만 보이는 현상)

## 🛠️ 작업 내용 (Changes)
1. **데이터 조회 로직 개선 (`lib/storage.ts`)**
   - 전역 상태(`CURRENT_PROJECT`)에 의존하던 `getWBSTasks` 대신, 명시적으로 ID를 받아 조회하는 `getProjectTasks(projectId)` 함수를 추가하고 적용했습니다.

2. **훅 초기값 설정 기능 추가 (`hooks/use-project-data.ts`)**
   - `useProjectData` 훅이 `initialData`를 인자로 받을 수 있도록 수정하여, 컴포넌트 마운트 시 즉시 데이터를 보여줄 수 있게 했습니다.

3. **데이터 흐름 연결 (`components/project-view.tsx`)**
   - `ProjectPage`에서 로드된 `project.wbsTasks` 데이터를 `ProjectView`를 거쳐 커스텀 훅의 초기값으로 주입했습니다.

## ✅ 결과 (Result)
- 이제 프로젝트 목록에서 클릭하여 진입하더라도 깜빡임이나 데이터 누락 없이 WBS 테이블이 정상적으로 렌더링됩니다.