### PR TITLE
[FIX] WBS 테이블 초기 렌더링 문제 해결 및 전역 상태 동기화

### DIFF
--- a/app/(dashboard)/project/[id]/(views)/wbs-table/page.tsx
+++ b/app/(dashboard)/project/[id]/(views)/wbs-table/page.tsx
@@ -8,10 +8,16 @@ import { WBSTableSkeleton } from '@/features/wbs/skeletons/WBSTableSkeleton';
  * URL: /project/[id]/wbs-table
  * 계층적 WBS 테이블 뷰를 렌더링합니다.
  */
-export default function WBSTablePage() {
+interface WBSTablePageProps {
+  params: {
+    id: string;
+  };
+}
+
+export default function WBSTablePage({ params }: WBSTablePageProps) {
   return (
     <Suspense fallback={<WBSTableSkeleton />}>
-      <WBSTableView />
+      <WBSTableView projectId={params.id} />
     </Suspense>
   );
 }

--- a/features/wbs/components/WBSTableView.tsx
+++ b/features/wbs/components/WBSTableView.tsx
@@ -1,40 +1,52 @@
 'use client';
 
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
 import { useParams } from 'next/navigation';
 import { useState, useCallback, useMemo } from 'react';
 import { HierarchicalWBSTable } from './HierarchicalWbsTable';
-import { useTaskOperations } from '../hooks/useTaskOperations';
 import { TaskDetailPanel } from '@/shared/components/project/TaskDetailPanel';
 import type { Task, BackendTask } from '@/shared/lib/apiTypes';
-import { apiService } from '@/shared/lib/apiService';
+import { useEffect } from 'react';
+import { useTaskStore } from '@/shared/stores/taskStore';
+import { WBSTableSkeleton } from '@/features/wbs/skeletons/WBSTableSkeleton';
+import { useTasks } from '@/shared/hooks/queries/useTaskQuery';
 
-/**
- * WBS Table View 컴포넌트
- *
- * 계층적 WBS 테이블을 렌더링합니다.
- */
+// 재귀적으로 작업 찾기 헬퍼 함수
+const findTaskRecursive = (tasks: Task[], taskId: string): Task | null => {
+  for (const task of tasks) {
+    if (task.task_id === taskId) {
+      return task;
+    }
+    if (task.subtasks && task.subtasks.length > 0) {
+      const found = findTaskRecursive(task.subtasks, taskId);
+      if (found) return found;
+    }
+  }
+  return null;
+};
 
-// 컴포넌트 밖 (export function WBSTableView() 위쪽)
-
-function buildTaskTree(backendTasks: BackendTask[]): Task[] {
-  if (!backendTasks) return [];
+function buildTaskTree(backendTasks: any[]): Task[] {
+  if (!backendTasks || !Array.isArray(backendTasks)) return [];
 
   const taskMap = new Map<string, Task>();
   const rootTasks: Task[] = [];
 
   // 1. 변환
   backendTasks.forEach((bt) => {
+    // BackendTask(id: number)와 CollaborativeTask(id: string) 모두 대응
+    const id = String(bt.id || bt.task_id);
+    const parent = bt.parent || bt.parent_id;
+
     const task: Task = {
-      task_id: String(bt.id),
-      parent_id: bt.parent === bt.id || !bt.parent ? null : String(bt.parent),
+      task_id: id,
+      parent_id: parent && parent !== id ? String(parent) : null,
       name: bt.name,
-      start_date: bt.start,
-      end_date: bt.end,
-      duration_days: bt.duration,
-      progress: bt.progress,
-      status: bt.status === 'TODO' ? '할일' : bt.status === 'IN_PROGRESS' ? '진행중' : '완료', // 백엔드 값에 맞춰 수정 필요
-      assignee: bt.assigneeEmail,
+      start_date: bt.start || bt.start_date,
+      end_date: bt.end || bt.end_date,
+      duration_days: bt.duration || bt.duration_days || 1,
+      progress: bt.progress || 0,
+      status: bt.status === 'TODO' ? '할일' : bt.status === 'IN_PROGRESS' ? '진행중' : '완료',
+      assignee: bt.assigneeEmail || bt.assignee || '',
       subtasks: [],
     };
     taskMap.set(task.task_id, task);
@@ -52,44 +64,83 @@ function buildTaskTree(backendTasks: BackendTask[]): Task[] {
   return rootTasks;
 }
 
-export function WBSTableView() {
+interface WBSTableViewProps {
+  projectId?: string;
+}
+
+export function WBSTableView({ projectId: propProjectId }: WBSTableViewProps) {
   const params = useParams();
-  const projectId = params.id as string;
+  const projectId = propProjectId || (params.id as string);
+
+  // Zustand Store Actions
+  const setTasks = useTaskStore((state) => state.setTasks);
+
+  const updateTask = useTaskStore((state) => state.updateTask);
+  const deleteTask = useTaskStore((state) => state.deleteTask);
+  const addTask = useTaskStore((state) => state.addTask);
   const queryClient = useQueryClient();
 
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
   const [isTaskDetailOpen, setIsTaskDetailOpen] = useState(false);
 
-  const { data: rawTasks = [], isLoading } = useQuery({
-    queryKey: ['tasks', projectId],
-    queryFn: () => apiService.getProjectTasks(projectId), // 이 줄이 핵심입니다!
-  });
+  const { data: rawTasks = [], isLoading } = useTasks(projectId);
 
-  const tasks = useMemo(() => {
+  const initialTasks = useMemo(() => {
     // buildTaskTree 함수가 없다면 아래에 정의해줘야 합니다.
     return buildTaskTree(rawTasks);
   }, [rawTasks]);
 
-  const { findTaskById, handleTaskUpdate, handleTaskDelete, handleTaskAdd } = useTaskOperations(
-    projectId,
-    tasks,
-    (updatedTasks) => {
-      queryClient.setQueryData(['tasks', projectId], updatedTasks);
+  const tasksFromStore = useTaskStore((state) => state.getTasks(projectId));
+
+  useEffect(() => {
+    if (initialTasks.length > 0) {
+      console.log(`[WBS] API 데이터 수신: ${initialTasks.length}건. 스토어 동기화 시도.`);
+      setTasks(projectId, initialTasks);
     }
-  );
+  }, [initialTasks, projectId, setTasks]);
+
+  // 렌더링용 데이터: 스토어에 데이터가 있으면 스토어 데이터 사용, 없으면 API 초기 데이터 사용 (깜빡임 방지)
+  const tasks = tasksFromStore.length > 0 ? tasksFromStore : initialTasks;
+
+  // Store 액션 래퍼 함수들 및 이벤트 핸들러
+  const handleTaskUpdate = (taskId: string, updates: Partial<Task>) => {
+    updateTask(projectId, taskId, updates);
+  };
+
+  const handleTaskDelete = (taskId: string) => {
+    deleteTask(projectId, taskId);
+  };
+
+  const handleTaskAdd = (parentId?: string, taskData?: Partial<Task>) => {
+    const newTask: Task = {
+      task_id: String(Date.now()), // 임시 ID 생성
+      name: taskData?.name || '새 작업',
+      start_date: taskData?.start_date || new Date().toISOString().split('T')[0],
+      end_date: taskData?.end_date || new Date().toISOString().split('T')[0],
+      duration_days: taskData?.duration_days || 1,
+      progress: 0,
+      status: '할일',
+      assignee: taskData?.assignee || '',
+      subtasks: [],
+      parent_id: parentId || null,
+      ...taskData,
+    };
+    addTask(projectId, newTask, parentId);
+  };
 
   const handleTaskSelect = useCallback(
     (taskId: string) => {
-      const task = findTaskById(tasks, taskId);
-      if (task) {
-        setSelectedTaskId(taskId);
-        setSelectedTask(task);
-        setIsTaskDetailOpen(true);
-      }
+      setSelectedTask(findTaskRecursive(tasks, taskId));
+      setSelectedTaskId(taskId);
+      setIsTaskDetailOpen(true);
     },
-    [tasks, findTaskById]
+    [tasks]
   );
+
+  if (isLoading) {
+    return <WBSTableSkeleton />;
+  }
 
   return (
     <>

--- a/shared/stores/taskStore.ts
+++ b/shared/stores/taskStore.ts
@@ -117,6 +117,8 @@ const groupTasksByStatus = (tasks: Task[]) => {
   };
 };
 
+const EMPTY_ARRAY: Task[] = [];
+
 // Zustand 스토어 생성
 export const useTaskStore = create<TaskState>()(
   devtools(
@@ -125,10 +127,14 @@ export const useTaskStore = create<TaskState>()(
         projectTasks: {},
 
         getTasks: (projectId: string) => {
-          return get().projectTasks[projectId] || [];
+          return get().projectTasks[projectId] || EMPTY_ARRAY;
         },
 
         setTasks: (projectId: string, tasks: Task[]) => {
+          const currentTasks = get().projectTasks[projectId];
+          // 참조가 완전히 동일한 경우에만 업데이트 건너뜀
+          if (currentTasks === tasks) return;
+
           set((state) => ({
             projectTasks: {
               ...state.projectTasks,


### PR DESCRIPTION
## 📌 작업 내용
- **WBS 데이터 로딩 수정**: WBS 테이블 진입 시 데이터가 렌더링되지 않고 간트 차트를 거쳐야만 보이던 문제를 해결했습니다.
- **데이터 소스 통일**: `WBSTableView`에서 개별 API 호출 대신 간트 차트와 동일한 `useTasks` 훅을 사용하도록 변경했습니다.
- **Zustand 스토어 연동**: API로 받아온 데이터를 전역 상태(`taskStore`)와 동기화하여 뷰 간 데이터 일관성을 확보했습니다.
- **트리 구조 변환 로직 개선**: 백엔드 데이터 타입(`BackendTask`)과 협업 데이터 타입(`CollaborativeTask`)의 ID 형식이 달라도 유연하게 처리하도록 `buildTaskTree` 함수를 개선했습니다.
- **버그 수정**: 조건부 렌더링으로 인해 발생하던 "Rendered more hooks" 에러를 수정했습니다.


