### PR TITLE
[FEAT] WBS 기능 구현 및 프로젝트 목록 페이지 개선

### DIFF
--- a/features/projects/components/ProjectListPage.tsx
+++ b/features/projects/components/ProjectListPage.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { Search, Calendar, Users, MoreVertical, Eye, Edit, Trash2, FolderOpen } from 'lucide-react';
+import { Search, Calendar, Users, MoreVertical, Eye, Trash2, FolderOpen } from 'lucide-react';
 import { Button } from '@/shared/ui/button';
 import { Input } from '@/shared/ui/input';
 import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/card';
@@ -29,6 +29,9 @@ interface ApiProject {
   endDate: string; // YYYY-MM-DD
   memberCount: number;
   updatedAt: string; // ISO string
+  team?: {
+    members: any[];
+  };
 }
 
 interface Project {
@@ -37,7 +40,7 @@ interface Project {
   description: string;
   startDate: string;
   endDate: string;
-  teamMembers: string[];
+  memberCount: number;
   createdAt: string;
   updatedAt: string;
 }
@@ -74,7 +77,7 @@ export function ProjectListPage({ onBack, onSelectProject }: ProjectListPageProp
         description: p.projectType || '프로젝트 상세 정보 없음', // projectType을 설명으로 임시 사용
         startDate: p.startDate,
         endDate: p.endDate,
-        teamMembers: [`${p.memberCount}명 참여`], // memberCount를 팀원 정보로 사용
+        memberCount: p.team?.members?.length || p.memberCount || 1,
         createdAt: new Date(p.updatedAt).toISOString(), // 생성일 필드가 없으므로 updatedAt 사용
         updatedAt: p.updatedAt,
       }));
@@ -93,16 +96,15 @@ export function ProjectListPage({ onBack, onSelectProject }: ProjectListPageProp
   }, []);
 
   const handleDeleteProject = async (projectId: string) => {
-    // NOTE: `confirm()` 사용은 금지되어 있으므로, 직접 API 호출 및 상태 업데이트로 대체합니다.
-    console.log(
-      `[ACTION] Attempting to delete project ID: ${projectId}. (Confirmation skipped as per guidelines)`
-    );
+    if (!window.confirm('정말로 이 프로젝트를 삭제하시겠습니까?')) {
+      return;
+    }
 
     try {
-      const BASE_URL = '/api';
+      const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
       const token = localStorage.getItem('authToken');
 
-      const response = await fetch(`${BASE_URL}/projects/${projectId}`, {
+      const response = await fetch(`${BASE_URL}/api/projects/${projectId}`, {
         method: 'DELETE',
         headers: {
           'Content-Type': 'application/json',
@@ -166,7 +168,11 @@ export function ProjectListPage({ onBack, onSelectProject }: ProjectListPageProp
         {/* 프로젝트 그리드 */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {filteredProjects.map((project) => (
-            <Card key={project.id} className="hover:shadow-lg transition-shadow">
+            <Card
+              key={project.id}
+              className="hover:shadow-lg transition-shadow cursor-pointer"
+              onClick={() => onSelectProject?.(project)}
+            >
               <CardHeader className="pb-3">
                 <div className="flex items-start justify-between">
                   <div className="flex-1">
@@ -177,7 +183,13 @@ export function ProjectListPage({ onBack, onSelectProject }: ProjectListPageProp
                   </div>
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
-                      <Button variant="ghost" size="icon" className="h-8 w-8">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        {' '}
                         <MoreVertical className="h-4 w-4" />
                       </Button>
                     </DropdownMenuTrigger>
@@ -185,10 +197,6 @@ export function ProjectListPage({ onBack, onSelectProject }: ProjectListPageProp
                       <DropdownMenuItem onClick={() => onSelectProject?.(project)}>
                         <Eye className="h-4 w-4 mr-2" />
                         보기
-                      </DropdownMenuItem>
-                      <DropdownMenuItem>
-                        <Edit className="h-4 w-4 mr-2" />
-                        편집
                       </DropdownMenuItem>
                       <DropdownMenuItem
                         className="text-red-600"
@@ -214,7 +222,7 @@ export function ProjectListPage({ onBack, onSelectProject }: ProjectListPageProp
                   </div>
                   <div className="flex items-center gap-2">
                     <Users className="h-4 w-4" />
-                    <span>{project.teamMembers.length}명 참여</span>
+                    <span>{project.memberCount}명 참여</span>
                   </div>
                 </div>
               </CardContent>

--- a/features/wbs/components/HierarchicalWbsTable.tsx
+++ b/features/wbs/components/HierarchicalWbsTable.tsx
@@ -14,7 +14,6 @@ interface HierarchicalWBSTableProps {
   onTaskUpdate: (taskId: string, updates: Partial<Task>) => void;
   onTaskDelete: (taskId: string) => void;
   onTaskAdd: (parentId?: string, taskData?: Partial<Task>) => void;
-  onTaskSelect?: (taskId: string) => void;
 }
 
 interface TaskRowProps {
@@ -30,7 +29,6 @@ interface TaskRowProps {
   onTaskUpdate: (taskId: string, updates: Partial<Task>) => void;
   onTaskDelete: (taskId: string) => void;
   onTaskAdd: (parentId?: string, taskData?: Partial<Task>) => void;
-  onTaskSelect?: (taskId: string) => void;
   setEditValues: (values: Partial<Task>) => void;
   creatingTask: string | null;
   newTaskValues: Partial<Task>;
@@ -53,7 +51,6 @@ function TaskRow({
   onTaskUpdate,
   onTaskDelete,
   onTaskAdd,
-  onTaskSelect,
   setEditValues,
   creatingTask,
   newTaskValues,
@@ -83,10 +80,7 @@ function TaskRow({
 
   return (
     <>
-      <TableRow
-        className="cursor-pointer hover:bg-muted/50"
-        onClick={() => onTaskSelect?.(task.task_id)}
-      >
+      <TableRow className="hover:bg-muted/50">
         <TableCell>
           {editingTask === task.task_id ? (
             <div style={{ paddingLeft }}>
@@ -155,15 +149,32 @@ function TaskRow({
         </TableCell>
         <TableCell>{formatDuration(task.duration_days)}</TableCell>
         <TableCell>
-          <div className="flex items-center space-x-2">
-            <div className="w-12 bg-muted rounded-full h-2">
-              <div
-                className="bg-primary h-2 rounded-full transition-all"
-                style={{ width: `${task.progress}%` }}
-              />
+          {editingTask === task.task_id ? (
+            <Input
+              type="number"
+              min="0"
+              max="100"
+              value={editValues.progress ?? task.progress}
+              onChange={(e) =>
+                setEditValues({
+                  ...editValues,
+                  progress: Math.min(100, Math.max(0, Number(e.target.value))),
+                })
+              }
+              className="h-8"
+              disabled={hasSubTasks} // 3. 자식 태스크가 있으면 수정 불가
+            />
+          ) : (
+            <div className="flex items-center space-x-2">
+              <div className="w-12 bg-muted rounded-full h-2">
+                <div
+                  className="bg-primary h-2 rounded-full transition-all"
+                  style={{ width: `${task.progress}%` }}
+                />
+              </div>
+              <span className="text-sm text-muted-foreground">{task.progress}%</span>
             </div>
-            <span className="text-sm text-muted-foreground">{task.progress}%</span>
-          </div>
+          )}
         </TableCell>
         <TableCell>
           {editingTask === task.task_id ? (
@@ -327,7 +338,6 @@ function TaskRow({
             onTaskUpdate={onTaskUpdate}
             onTaskDelete={onTaskDelete}
             onTaskAdd={onTaskAdd}
-            onTaskSelect={onTaskSelect}
             setEditValues={setEditValues}
             creatingTask={creatingTask}
             newTaskValues={newTaskValues}
@@ -432,7 +442,6 @@ export function HierarchicalWBSTable({
   onTaskUpdate,
   onTaskDelete,
   onTaskAdd,
-  onTaskSelect,
 }: HierarchicalWBSTableProps) {
   const [editingTask, setEditingTask] = useState<string | null>(null);
   const [editValues, setEditValues] = useState<Partial<Task>>({});
@@ -448,6 +457,18 @@ export function HierarchicalWBSTable({
     progress: 0,
     status: '할일',
   });
+
+  // 2. 모든 ID 수집 헬퍼 함수 (펼치기/접기용)
+  const getAllTaskIds = (nodes: Task[]): string[] => {
+    let ids: string[] = [];
+    nodes.forEach((node) => {
+      ids.push(node.task_id);
+      if (node.subtasks && node.subtasks.length > 0) {
+        ids = [...ids, ...getAllTaskIds(node.subtasks)];
+      }
+    });
+    return ids;
+  };
 
   const handleToggleExpand = (taskId: string) => {
     const newExpanded = new Set(expandedTasks);
@@ -527,7 +548,7 @@ export function HierarchicalWBSTable({
           <Button
             variant="outline"
             size="sm"
-            onClick={() => setExpandedTasks(new Set(tasks.map((t) => t.id)))}
+            onClick={() => setExpandedTasks(new Set(getAllTaskIds(tasks)))}
           >
             모두 펼치기
           </Button>
@@ -663,7 +684,6 @@ export function HierarchicalWBSTable({
                 onTaskUpdate={onTaskUpdate}
                 onTaskDelete={onTaskDelete}
                 onTaskAdd={onTaskAdd}
-                onTaskSelect={onTaskSelect}
                 setEditValues={setEditValues}
                 creatingTask={creatingTask}
                 newTaskValues={newTaskValues}

--- a/features/wbs/components/WBSTableView.tsx
+++ b/features/wbs/components/WBSTableView.tsx
@@ -1,15 +1,16 @@
 'use client';
 
-import { useQueryClient } from '@tanstack/react-query';
 import { useParams } from 'next/navigation';
-import { useState, useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
 import { HierarchicalWBSTable } from './HierarchicalWbsTable';
-import { TaskDetailPanel } from '@/shared/components/project/TaskDetailPanel';
 import type { Task, BackendTask } from '@/shared/lib/apiTypes';
-import { useEffect } from 'react';
-import { useTaskStore } from '@/shared/stores/taskStore';
 import { WBSTableSkeleton } from '@/features/wbs/skeletons/WBSTableSkeleton';
-import { useTasks } from '@/shared/hooks/queries/useTaskQuery';
+import {
+  useTasks,
+  useCreateTask,
+  useUpdateTask,
+  useDeleteTask,
+} from '@/shared/hooks/queries/useTaskQuery';
 
 // 재귀적으로 작업 찾기 헬퍼 함수
 const findTaskRecursive = (tasks: Task[], taskId: string): Task | null => {
@@ -72,17 +73,9 @@ export function WBSTableView({ projectId: propProjectId }: WBSTableViewProps) {
   const params = useParams();
   const projectId = propProjectId || (params.id as string);
 
-  // Zustand Store Actions
-  const setTasks = useTaskStore((state) => state.setTasks);
-
-  const updateTask = useTaskStore((state) => state.updateTask);
-  const deleteTask = useTaskStore((state) => state.deleteTask);
-  const addTask = useTaskStore((state) => state.addTask);
-  const queryClient = useQueryClient();
-
-  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
-  const [selectedTask, setSelectedTask] = useState<Task | null>(null);
-  const [isTaskDetailOpen, setIsTaskDetailOpen] = useState(false);
+  const createTaskMutation = useCreateTask(projectId);
+  const updateTaskMutation = useUpdateTask(projectId);
+  const deleteTaskMutation = useDeleteTask(projectId);
 
   const { data: rawTasks = [], isLoading } = useTasks(projectId);
 
@@ -91,28 +84,48 @@ export function WBSTableView({ projectId: propProjectId }: WBSTableViewProps) {
     return buildTaskTree(rawTasks);
   }, [rawTasks]);
 
-  const tasksFromStore = useTaskStore((state) => state.getTasks(projectId));
-
-  useEffect(() => {
-    if (initialTasks.length > 0) {
-      console.log(`[WBS] API 데이터 수신: ${initialTasks.length}건. 스토어 동기화 시도.`);
-      setTasks(projectId, initialTasks);
-    }
-  }, [initialTasks, projectId, setTasks]);
-
-  // 렌더링용 데이터: 스토어에 데이터가 있으면 스토어 데이터 사용, 없으면 API 초기 데이터 사용 (깜빡임 방지)
-  const tasks = tasksFromStore.length > 0 ? tasksFromStore : initialTasks;
+  // 렌더링용 데이터: API 데이터 사용
+  const tasks = initialTasks;
 
   // Store 액션 래퍼 함수들 및 이벤트 핸들러
   const handleTaskUpdate = (taskId: string, updates: Partial<Task>) => {
-    updateTask(projectId, taskId, updates);
+    // 4. 상태나 진행률 변경 시 값 동기화 로직
+    const newUpdates: any = { ...updates };
+
+    // 상태 변경 시: 한글 상태를 백엔드 Enum으로 변환하고 진행률 동기화
+    if (updates.status) {
+      let backendStatus = updates.status as string;
+      if (updates.status === '할일') backendStatus = 'TODO';
+      else if (updates.status === '진행중') backendStatus = 'IN_PROGRESS';
+      else if (updates.status === '완료') backendStatus = 'DONE';
+
+      newUpdates.status = backendStatus;
+
+      if (backendStatus === 'TODO') newUpdates.progress = 0;
+      else if (backendStatus === 'IN_PROGRESS') newUpdates.progress = 1;
+      else if (backendStatus === 'DONE') newUpdates.progress = 100;
+    }
+
+    // 진행률 변경 시: 상태 동기화
+    if (updates.progress !== undefined) {
+      if (updates.progress === 0) newUpdates.status = 'TODO';
+      else if (updates.progress === 100) newUpdates.status = 'DONE';
+      else newUpdates.status = 'IN_PROGRESS';
+    }
+
+    updateTaskMutation.mutate({ taskId: Number(taskId), updates: newUpdates });
   };
 
   const handleTaskDelete = (taskId: string) => {
-    deleteTask(projectId, taskId);
+    deleteTaskMutation.mutate(Number(taskId));
   };
 
   const handleTaskAdd = (parentId?: string, taskData?: Partial<Task>) => {
+    // 상태 매핑 (한글 -> 백엔드 Enum)
+    let backendStatus = 'TODO';
+    if (taskData?.status === '진행중') backendStatus = 'IN_PROGRESS';
+    else if (taskData?.status === '완료') backendStatus = 'DONE';
+
     const newTask: Task = {
       task_id: String(Date.now()), // 임시 ID 생성
       name: taskData?.name || '새 작업',
@@ -126,17 +139,13 @@ export function WBSTableView({ projectId: propProjectId }: WBSTableViewProps) {
       parent_id: parentId || null,
       ...taskData,
     };
-    addTask(projectId, newTask, parentId);
+    // API 호출 시에는 필요한 데이터만 전송 (ID는 백엔드 생성)
+    createTaskMutation.mutate({
+      ...newTask,
+      status: backendStatus,
+      parent: parentId ? Number(parentId) : undefined,
+    } as any);
   };
-
-  const handleTaskSelect = useCallback(
-    (taskId: string) => {
-      setSelectedTask(findTaskRecursive(tasks, taskId));
-      setSelectedTaskId(taskId);
-      setIsTaskDetailOpen(true);
-    },
-    [tasks]
-  );
 
   if (isLoading) {
     return <WBSTableSkeleton />;
@@ -149,14 +158,6 @@ export function WBSTableView({ projectId: propProjectId }: WBSTableViewProps) {
         onTaskUpdate={handleTaskUpdate}
         onTaskDelete={handleTaskDelete}
         onTaskAdd={handleTaskAdd}
-        onTaskSelect={handleTaskSelect}
-      />
-
-      <TaskDetailPanel
-        task={selectedTask}
-        isOpen={isTaskDetailOpen}
-        onClose={() => setIsTaskDetailOpen(false)}
-        onUpdate={handleTaskUpdate}
       />
     </>
   );


### PR DESCRIPTION
## 📋 작업 내용

이번 PR에서는 WBS 테이블의 핵심 기능을 구현하고, 프로젝트 목록 페이지를 개선하여 API와 연동했습니다.

### 🚀 주요 변경 사항

#### 1. WBS 테이블 (1~5번)
- **초기 로딩 문제 해결**: WBS 페이지에 직접 접근 시 데이터가 보이지 않던 문제를 해결했습니다.
- **CUD API 연동**: 작업의 생성(Create), 수정(Update), 삭제(Delete) 기능을 실제 백엔드 API와 연동했습니다.
- **상태/진행률 동기화**: 작업의 '상태'와 '진행률'이 서로 연동되어 변경되도록 로직을 추가했습니다. (예: '완료' 시 진행률 100%)
- **진행률 수정 제한**: 하위 작업이 있는 부모 작업의 진행률은 직접 수정할 수 없도록 제한했습니다.
- **UI 개선**: 작업 클릭 시 나타나던 우측 상세 패널을 제거하고, '모두 펼치기/접기' 기능을 구현했습니다.

#### 2. 프로젝트 목록 페이지 (6~8번)
- **삭제 기능 연동**: 프로젝트 삭제 버튼을 API와 연동하고, 확인 창을 추가했습니다.
- **UI 정리**: 불필요한 '편집' 버튼을 제거했습니다.
- **인원 수 표시**: API의 `memberCount`를 받아와 인원 수를 표시하도록 연결했습니다. (현재 백엔드에서 1로 고정되어 있으나, 추후 백엔드 수정 시 자동 반영됩니다.)
- **UX 개선**: 프로젝트 카드 전체를 클릭하여 상세 페이지로 이동할 수 있도록 개선했습니다.

## ✅ 관련 작업
- WBS 테이블 기능 구현 (1, 2, 3, 4, 5번)
- 프로젝트 목록 기능 구현 (6, 7, 8번)
