### PR TITLE
[FEAT] WBS 테이블 담당자 관리 기능 개선 및 버그 수정/project list ux

### DIFF
--- a/features/projects/components/ProjectListPage.tsx
+++ b/features/projects/components/ProjectListPage.tsx
@@ -93,6 +93,11 @@ export function ProjectListPage({ onBack, onSelectProject }: ProjectListPageProp
 
   useEffect(() => {
     loadProjects();
+
+    // 로그인/로그아웃 이벤트 감지하여 목록 새로고침
+    const handleAuthChange = () => loadProjects();
+    window.addEventListener('auth-change', handleAuthChange);
+    return () => window.removeEventListener('auth-change', handleAuthChange);
   }, []);
 
   const handleDeleteProject = async (projectId: string) => {
@@ -200,7 +205,10 @@ export function ProjectListPage({ onBack, onSelectProject }: ProjectListPageProp
                       </DropdownMenuItem>
                       <DropdownMenuItem
                         className="text-red-600"
-                        onClick={() => handleDeleteProject(project.id)}
+                        onClick={(e) => {
+                          e.stopPropagation(); // 클릭 이벤트 전파 방지 (상세 페이지 이동 막기)
+                          handleDeleteProject(project.id);
+                        }}
                       >
                         <Trash2 className="h-4 w-4 mr-2" />
                         삭제

--- a/features/wbs/components/HierarchicalWbsTable.tsx
+++ b/features/wbs/components/HierarchicalWbsTable.tsx
@@ -7,10 +7,11 @@ import { Badge } from '@/shared/ui/badge';
 import { Input } from '@/shared/ui/input';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/shared/ui/table';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shared/ui/select';
-import type { Task } from '@/shared/lib/apiTypes';
+import type { Task, TeamMember } from '@/shared/lib/apiTypes';
 
 interface HierarchicalWBSTableProps {
   tasks: Task[];
+  members: TeamMember[];
   onTaskUpdate: (taskId: string, updates: Partial<Task>) => void;
   onTaskDelete: (taskId: string) => void;
   onTaskAdd: (parentId?: string, taskData?: Partial<Task>) => void;
@@ -18,6 +19,7 @@ interface HierarchicalWBSTableProps {
 
 interface TaskRowProps {
   task: Task;
+  members: TeamMember[];
   depth: number;
   expandedTasks: Set<string>;
   onToggleExpand: (taskId: string) => void;
@@ -40,6 +42,7 @@ interface TaskRowProps {
 
 function TaskRow({
   task,
+  members,
   depth,
   expandedTasks,
   onToggleExpand,
@@ -78,6 +81,18 @@ function TaskRow({
     return `${days}일`;
   };
 
+  // 현재 담당자 값(이름 또는 이메일)을 이메일로 변환하는 헬퍼 함수
+  const getAssigneeValue = (val: string | undefined) => {
+    if (!val) return '';
+    // 1. 이미 이메일인 경우 (수정 중)
+    const byEmail = members.find((m) => m.email === val);
+    if (byEmail) return byEmail.email;
+    // 2. 이름인 경우 (초기 상태) -> 이메일로 변환
+    const byName = members.find((m) => m.name === val);
+    if (byName) return byName.email;
+    return '';
+  };
+
   return (
     <>
       <TableRow className="hover:bg-muted/50">
@@ -114,11 +129,21 @@ function TaskRow({
         </TableCell>
         <TableCell>
           {editingTask === task.task_id ? (
-            <Input
-              value={editValues.assignee || ''}
-              onChange={(e) => setEditValues({ ...editValues, assignee: e.target.value })}
-              className="h-8"
-            />
+            <Select
+              value={getAssigneeValue(editValues.assignee)}
+              onValueChange={(value) => setEditValues({ ...editValues, assignee: value })}
+            >
+              <SelectTrigger className="h-8">
+                <SelectValue placeholder="담당자" />
+              </SelectTrigger>
+              <SelectContent>
+                {members.map((member) => (
+                  <SelectItem key={member.id} value={member.email}>
+                    {member.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           ) : (
             task.assignee
           )}
@@ -249,12 +274,21 @@ function TaskRow({
             </div>
           </TableCell>
           <TableCell>
-            <Input
+            <Select
               value={newTaskValues.assignee || ''}
-              onChange={(e) => setNewTaskValues({ ...newTaskValues, assignee: e.target.value })}
-              placeholder="담당자"
-              className="h-8"
-            />
+              onValueChange={(value) => setNewTaskValues({ ...newTaskValues, assignee: value })}
+            >
+              <SelectTrigger className="h-8">
+                <SelectValue placeholder="담당자" />
+              </SelectTrigger>
+              <SelectContent>
+                {members.map((member) => (
+                  <SelectItem key={member.id} value={member.email}>
+                    {member.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </TableCell>
           <TableCell>
             <Input
@@ -327,6 +361,7 @@ function TaskRow({
           <TaskRow
             key={subTask.task_id}
             task={subTask}
+            members={members}
             depth={depth + 1}
             expandedTasks={expandedTasks}
             onToggleExpand={onToggleExpand}
@@ -362,12 +397,21 @@ function TaskRow({
             </div>
           </TableCell>
           <TableCell>
-            <Input
+            <Select
               value={newTaskValues.assignee || ''}
-              onChange={(e) => setNewTaskValues({ ...newTaskValues, assignee: e.target.value })}
-              placeholder="담당자"
-              className="h-8"
-            />
+              onValueChange={(value) => setNewTaskValues({ ...newTaskValues, assignee: value })}
+            >
+              <SelectTrigger className="h-8">
+                <SelectValue placeholder="담당자" />
+              </SelectTrigger>
+              <SelectContent>
+                {members.map((member) => (
+                  <SelectItem key={member.id} value={member.email}>
+                    {member.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </TableCell>
           <TableCell>
             <Input
@@ -439,6 +483,7 @@ function TaskRow({
 
 export function HierarchicalWBSTable({
   tasks,
+  members,
   onTaskUpdate,
   onTaskDelete,
   onTaskAdd,
@@ -591,14 +636,23 @@ export function HierarchicalWBSTable({
                   </div>
                 </TableCell>
                 <TableCell>
-                  <Input
+                  <Select
                     value={newTaskValues.assignee || ''}
-                    onChange={(e) =>
-                      setNewTaskValues({ ...newTaskValues, assignee: e.target.value })
+                    onValueChange={(value) =>
+                      setNewTaskValues({ ...newTaskValues, assignee: value })
                     }
-                    placeholder="담당자"
-                    className="h-8"
-                  />
+                  >
+                    <SelectTrigger className="h-8">
+                      <SelectValue placeholder="담당자" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {members.map((member) => (
+                        <SelectItem key={member.id} value={member.email}>
+                          {member.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                 </TableCell>
                 <TableCell>
                   <Input
@@ -673,6 +727,7 @@ export function HierarchicalWBSTable({
               <TaskRow
                 key={task.task_id}
                 task={task}
+                members={members}
                 depth={0}
                 expandedTasks={expandedTasks}
                 onToggleExpand={handleToggleExpand}

--- a/features/wbs/components/WBSTableView.tsx
+++ b/features/wbs/components/WBSTableView.tsx
@@ -1,10 +1,14 @@
 'use client';
 
+import { useQuery } from '@tanstack/react-query';
+
 import { useParams } from 'next/navigation';
 import { useMemo } from 'react';
 import { HierarchicalWBSTable } from './HierarchicalWbsTable';
 import type { Task, BackendTask } from '@/shared/lib/apiTypes';
 import { WBSTableSkeleton } from '@/features/wbs/skeletons/WBSTableSkeleton';
+import { fetchProjectMembers } from '@/shared/api/memberApi';
+
 import {
   useTasks,
   useCreateTask,
@@ -35,19 +39,22 @@ function buildTaskTree(backendTasks: any[]): Task[] {
   // 1. 변환
   backendTasks.forEach((bt) => {
     // BackendTask(id: number)와 CollaborativeTask(id: string) 모두 대응
-    const id = String(bt.id || bt.task_id);
-    const parent = bt.parent || bt.parent_id;
+    const idVal = bt.id ?? bt.task_id;
+    if (idVal === undefined || idVal === null) return; // ID가 없으면 건너뜀
+
+    const id = String(idVal);
+    const parentVal = bt.parent ?? bt.parent_id;
 
     const task: Task = {
       task_id: id,
-      parent_id: parent && parent !== id ? String(parent) : null,
+      parent_id: parentVal && String(parentVal) !== id ? String(parentVal) : null,
       name: bt.name,
       start_date: bt.start || bt.start_date,
       end_date: bt.end || bt.end_date,
       duration_days: bt.duration || bt.duration_days || 1,
       progress: bt.progress || 0,
       status: bt.status === 'TODO' ? '할일' : bt.status === 'IN_PROGRESS' ? '진행중' : '완료',
-      assignee: bt.assigneeEmail || bt.assignee || '',
+      assignee: bt.assigneeName || bt.assigneeEmail || bt.assignee || '',
       subtasks: [],
     };
     taskMap.set(task.task_id, task);
@@ -79,6 +86,23 @@ export function WBSTableView({ projectId: propProjectId }: WBSTableViewProps) {
 
   const { data: rawTasks = [], isLoading } = useTasks(projectId);
 
+  // 팀원 목록 조회
+  const { data: teamMembers = [] } = useQuery({
+    queryKey: ['teamMembers', projectId],
+    queryFn: async () => {
+      const members = await fetchProjectMembers(projectId);
+      return members.map((m: any) => ({
+        id: String(m.memberId),
+        name: m.userName,
+        email: m.userEmail,
+        role: m.role === 'OWNER' ? 'owner' : m.role === 'EDITOR' ? 'member' : 'viewer',
+        status: 'active',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      }));
+    },
+  });
+
   const initialTasks = useMemo(() => {
     // buildTaskTree 함수가 없다면 아래에 정의해줘야 합니다.
     return buildTaskTree(rawTasks);
@@ -89,31 +113,62 @@ export function WBSTableView({ projectId: propProjectId }: WBSTableViewProps) {
 
   // Store 액션 래퍼 함수들 및 이벤트 핸들러
   const handleTaskUpdate = (taskId: string, updates: Partial<Task>) => {
-    // 4. 상태나 진행률 변경 시 값 동기화 로직
-    const newUpdates: any = { ...updates };
+    const originalTask = findTaskRecursive(tasks, taskId);
+    if (!originalTask) return;
 
-    // 상태 변경 시: 한글 상태를 백엔드 Enum으로 변환하고 진행률 동기화
-    if (updates.status) {
-      let backendStatus = updates.status as string;
-      if (updates.status === '할일') backendStatus = 'TODO';
-      else if (updates.status === '진행중') backendStatus = 'IN_PROGRESS';
-      else if (updates.status === '완료') backendStatus = 'DONE';
-
-      newUpdates.status = backendStatus;
-
-      if (backendStatus === 'TODO') newUpdates.progress = 0;
-      else if (backendStatus === 'IN_PROGRESS') newUpdates.progress = 1;
-      else if (backendStatus === 'DONE') newUpdates.progress = 100;
+    const payload: any = {};
+    // 1. 날짜/기간/이름 변경 확인 (값이 변경된 경우에만 payload에 추가)
+    if (updates.start_date && updates.start_date !== originalTask.start_date) {
+      payload.startDate = updates.start_date;
+    }
+    if (updates.end_date && updates.end_date !== originalTask.end_date) {
+      payload.endDate = updates.end_date;
+    }
+    if (
+      updates.duration_days !== undefined &&
+      updates.duration_days !== originalTask.duration_days
+    ) {
+      payload.duration = updates.duration_days;
+    }
+    if (updates.name && updates.name !== originalTask.name) {
+      payload.name = updates.name;
     }
 
-    // 진행률 변경 시: 상태 동기화
-    if (updates.progress !== undefined) {
-      if (updates.progress === 0) newUpdates.status = 'TODO';
-      else if (updates.progress === 100) newUpdates.status = 'DONE';
-      else newUpdates.status = 'IN_PROGRESS';
+    // 2. 담당자 변경 확인 (변경된 경우에만 전송하여 불필요한 404 에러 방지)
+    if (updates.assignee !== undefined && updates.assignee !== originalTask.assignee) {
+      payload.assigneeEmail = updates.assignee;
+    }
+    // 3. 상태/진행률 변경 로직 (상호 의존성 처리)
+    const statusChanged = updates.status && updates.status !== originalTask.status;
+    const progressChanged =
+      updates.progress !== undefined && updates.progress !== originalTask.progress;
+
+    if (statusChanged || progressChanged) {
+      let newStatus = updates.status || originalTask.status;
+      let newProgress = updates.progress !== undefined ? updates.progress : originalTask.progress;
+
+      if (statusChanged && !progressChanged) {
+        if (newStatus === '할일') newProgress = 0;
+        else if (newStatus === '진행중') newProgress = 1;
+        else if (newStatus === '완료') newProgress = 100;
+      } else if (progressChanged && !statusChanged) {
+        if (newProgress === 0) newStatus = '할일';
+        else if (newProgress === 100) newStatus = '완료';
+        else newStatus = '진행중';
+      }
+
+      let backendStatus = 'TODO';
+      if (newStatus === '진행중') backendStatus = 'IN_PROGRESS';
+      else if (newStatus === '완료') backendStatus = 'DONE';
+
+      payload.status = backendStatus;
+      payload.progress = newProgress;
     }
 
-    updateTaskMutation.mutate({ taskId: Number(taskId), updates: newUpdates });
+    // 변경사항이 없으면 요청을 보내지 않음
+    if (Object.keys(payload).length === 0) return;
+
+    updateTaskMutation.mutate({ taskId: Number(taskId), updates: payload });
   };
 
   const handleTaskDelete = (taskId: string) => {
@@ -126,25 +181,20 @@ export function WBSTableView({ projectId: propProjectId }: WBSTableViewProps) {
     if (taskData?.status === '진행중') backendStatus = 'IN_PROGRESS';
     else if (taskData?.status === '완료') backendStatus = 'DONE';
 
-    const newTask: Task = {
-      task_id: String(Date.now()), // 임시 ID 생성
+    // 생성 시에는 필수 필드만 깔끔하게 전송
+    const payload: any = {
       name: taskData?.name || '새 작업',
-      start_date: taskData?.start_date || new Date().toISOString().split('T')[0],
-      end_date: taskData?.end_date || new Date().toISOString().split('T')[0],
-      duration_days: taskData?.duration_days || 1,
-      progress: 0,
-      status: '할일',
-      assignee: taskData?.assignee || '',
-      subtasks: [],
-      parent_id: parentId || null,
-      ...taskData,
-    };
-    // API 호출 시에는 필요한 데이터만 전송 (ID는 백엔드 생성)
-    createTaskMutation.mutate({
-      ...newTask,
       status: backendStatus,
       parent: parentId ? Number(parentId) : undefined,
-    } as any);
+      startDate: taskData?.start_date || new Date().toISOString().split('T')[0],
+      endDate: taskData?.end_date || new Date().toISOString().split('T')[0],
+      duration: taskData?.duration_days || 1,
+      assigneeEmail: taskData?.assignee || '',
+      progress: 0,
+    };
+
+    // API 호출 시에는 필요한 데이터만 전송 (ID는 백엔드 생성)
+    createTaskMutation.mutate(payload);
   };
 
   if (isLoading) {
@@ -155,6 +205,7 @@ export function WBSTableView({ projectId: propProjectId }: WBSTableViewProps) {
     <>
       <HierarchicalWBSTable
         tasks={tasks}
+        members={teamMembers}
         onTaskUpdate={handleTaskUpdate}
         onTaskDelete={handleTaskDelete}
         onTaskAdd={handleTaskAdd}

--- a/shared/hooks/queries/useTaskQuery.ts
+++ b/shared/hooks/queries/useTaskQuery.ts
@@ -31,6 +31,7 @@ export const useProjectWithTasks = (projectId: string) => {
     queryKey: ['projectWithTasks', projectId],
     queryFn: async () => {
       const response = await fetchTasks(projectId);
+
       return {
         project: {
           id: response.projectId,

--- a/shared/layout/SidebarProfile.tsx
+++ b/shared/layout/SidebarProfile.tsx
@@ -63,6 +63,10 @@ export function SidebarProfile({ collapsed }: SidebarProfileProps) {
     localStorage.setItem('user', JSON.stringify(loggedInUser));
     setIsAuthenticated(true);
     setUser(loggedInUser);
+
+    // 로그인 성공 이벤트 발생 (프로젝트 목록 갱신용)
+    window.dispatchEvent(new Event('auth-change'));
+
     router.refresh();
   };
 
@@ -81,22 +85,6 @@ export function SidebarProfile({ collapsed }: SidebarProfileProps) {
               onLoginError={handleLoginError}
             />
           </div>
-          {/* 
-          <div className="px-4 pb-4">
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button variant="ghost" size="icon" className="w-full" asChild>
-                    <Link href="/settings">
-                      <Settings className="h-4 w-4" />
-                      <span className="sr-only">설정</span>
-                    </Link>
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="right">설정</TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          </div> */}
         </div>
       );
     }
@@ -156,22 +144,6 @@ export function SidebarProfile({ collapsed }: SidebarProfileProps) {
             </div>
           )}
         </div>
-        {/* 
-        <div className="px-4 pb-4">
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button variant="ghost" size="icon" className="w-full" asChild>
-                  <Link href="/settings">
-                    <Settings className="h-4 w-4" />
-                    <span className="sr-only">설정</span>
-                  </Link>
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="right">설정</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        </div> */}
       </div>
     );
   }
@@ -187,15 +159,6 @@ export function SidebarProfile({ collapsed }: SidebarProfileProps) {
             onLoginError={handleLoginError}
           />
         </div>
-
-        {/* <div className="px-4 pb-4">
-          <Button variant="ghost" className="w-full justify-start gap-3 px-2" asChild>
-            <Link href="/settings">
-              <Settings className="h-4 w-4" />
-              <span>설정</span>
-            </Link>
-          </Button>
-        </div> */}
       </div>
     );
   }
@@ -227,12 +190,6 @@ export function SidebarProfile({ collapsed }: SidebarProfileProps) {
 
         {isOpen && (
           <div className="mt-1 space-y-1">
-            {/* <Button variant="ghost" className="w-full justify-start gap-3 px-2" asChild>
-              <Link href="/profile">
-                <User className="h-4 w-4" />
-                <span>프로필</span>
-              </Link>
-            </Button> */}
             <Button
               variant="ghost"
               className="w-full justify-start gap-3 px-2"
@@ -244,15 +201,6 @@ export function SidebarProfile({ collapsed }: SidebarProfileProps) {
           </div>
         )}
       </div>
-      {/* 
-      <div className="px-4 pb-4">
-        <Button variant="ghost" className="w-full justify-start gap-3 px-2" asChild>
-          <Link href="/settings">
-            <Settings className="h-4 w-4" />
-            <span>설정</span>
-          </Link>
-        </Button>
-      </div> */}
     </div>
   );
 }

--- a/shared/lib/apiService.ts
+++ b/shared/lib/apiService.ts
@@ -329,12 +329,21 @@ class ApiService {
 
   // 팀 관리 관련
   async getTeamMembers(projectId: string): Promise<TeamMember[]> {
-    const mockTeamMembersData = await import('./collaborationMockData');
+    const endpoint = `/api/projects/${projectId}/members`;
+    const response = await this.request<any[]>(endpoint);
 
-    // Simulate API delay
-    await new Promise((resolve) => setTimeout(resolve, 500));
-
-    return mockTeamMembersData.mockTeamMembers;
+    if (response.success && response.data) {
+      return response.data.map((m: any) => ({
+        id: String(m.userId),
+        name: m.userName,
+        email: m.userEmail,
+        role: m.role === 'OWNER' ? 'owner' : m.role === 'EDITOR' ? 'member' : 'viewer',
+        status: 'active',
+        createdAt: m.joinedAt || new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      }));
+    }
+    return [];
   }
 
   async inviteTeamMember(projectId: string, email: string, role: UserRole): Promise<void> {


### PR DESCRIPTION
## 📋 작업 내용

WBS 테이블에서 담당자 할당 방식을 개선하고, 데이터 수정 시 발생하던 API 연동 문제를 해결했습니다.

### 🚀 주요 변경 사항

#### 1. 담당자 관리 개선
- **드롭다운 적용**: 기존 텍스트 입력 방식을 `Select` 드롭다운으로 변경하여, 실제 프로젝트 팀원 목록 중에서만 담당자를 선택할 수 있도록 개선했습니다.
- **팀원 목록 연동**: WBS 뷰 진입 시 실제 프로젝트 멤버 데이터를 불러오도록 API 연동을 수정했습니다.

#### 2. 데이터 수정 로직 정상화
- **필드명 매핑 수정**: 작업 수정(`Update`) 및 추가(`Create`) 시 프론트엔드 필드명(`start_date`, `assignee` 등)을 백엔드 API가 기대하는 필드명(`startDate`, `assigneeEmail` 등)으로 올바르게 변환하여 전송하도록 수정했습니다.
- **Diffing 로직 개선**: 변경된 값만 선별하여 전송함으로써 불필요한 데이터 전송 및 잠재적인 오류를 방지했습니다.

#### 3. 버그 수정
- **담당자 표시 오류 해결**: API 응답의 `assigneeName`을 우선적으로 확인하여 담당자 이름이 정상적으로 표시되도록 수정했습니다.
